### PR TITLE
Add blendkit search

### DIFF
--- a/roboprop_client/tests.py
+++ b/roboprop_client/tests.py
@@ -285,6 +285,58 @@ class MyModelsUploadTestCase(TestCase):
         self.assertEqual(str(messages[0]), "Failed to upload model")
 
 
+class AddToMyModelsTestCase(TestCase):
+    def setUp(self):
+        self.client = Client()
+
+    @patch("roboprop_client.views.__add_fuel_model_to_my_models")
+    def test_add_fuel_model_to_my_models(self, mock_add_fuel_model_to_my_models):
+        mock_add_fuel_model_to_my_models.return_value = Mock(status_code=201)
+        response = self.client.post(
+            "/add-to-my-models/",
+            {"name": "test_model", "library": "fuel", "owner": "test_owner"},
+        )
+        # Confirm correct arguments
+        mock_add_fuel_model_to_my_models.assert_called_once_with(
+            "test_model", "test_owner"
+        )
+
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(
+            response.json(),
+            {"message": "Success: Model: test_model added to My Models"},
+        )
+
+    @patch("roboprop_client.views.__add_blendkit_model_to_my_models")
+    def test_add_blendkit_model_to_my_models(
+        self, mock_add_blendkit_model_to_my_models
+    ):
+        mock_add_blendkit_model_to_my_models.return_value = Mock(status_code=400)
+        response = self.client.post(
+            "/add-to-my-models/",
+            {
+                "name": "test_model",
+                "library": "blendkit",
+                "assetBaseId": "test_asset_base_id",
+                "thumbnail": "test_thumbnail",
+            },
+        )
+        # Confirm correct arguments
+        mock_add_blendkit_model_to_my_models.assert_called_once_with("test_thumbnail")
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            response.json(),
+            {"error": "Failed to add model: test_model to My Models"},
+        )
+
+    def test_invalid_request_method(self):
+        response = self.client.get("/add-to-my-models/")
+
+        self.assertEqual(response.status_code, 405)
+        self.assertEqual(response.json(), {"error": "Invalid request method"})
+
+
 """
 At present, flatten_dict is designed to be used with
 model.config files, i.e for metadata, where a huge amount of nesting / 

--- a/roboprop_client/views.py
+++ b/roboprop_client/views.py
@@ -73,6 +73,20 @@ def _get_model_configuration(model):
     return model_configuration
 
 
+def __search_fuel(search):
+    fuel_url = f"https://fuel.gazebosim.org/1.0/models?q={search}"
+    fuel_response = requests.get(fuel_url)
+    fuel_search_results = fuel_response.json()
+    return fuel_search_results
+
+
+def __search_blendkit(search):
+    blendkit_url = f"https://www.blenderkit.com/api/v1/search/?query=search+text:{search}+asset_type:model+order:_score+is_free:True&page=1"
+    blendkit_response = requests.get(blendkit_url)
+    blendkit_search_results = blendkit_response.json()
+    return blendkit_search_results
+
+
 def _search_and_cache(search):
     # Check if the results are already cached
     cache_key = f"search_results_{search}"
@@ -84,10 +98,9 @@ def _search_and_cache(search):
         fuel_search_results = {}
         blendkit_search_results = {}
         # Search Fuel
-        fuel_url = f"https://fuel.gazebosim.org/1.0/models?q={search}"
-        fuel_response = requests.get(fuel_url)
-        fuel_search_results = fuel_response.json()
-        search_results["fuel"] = fuel_search_results
+        search_results["fuel"] = __search_fuel(search)
+        # Search BlendKit
+        search_results["blendkit"] = __search_blendkit(search)
         # Cache the results for 5 minutes
         cache.set(cache_key, search_results, 300)
 

--- a/roboprop_client/views.py
+++ b/roboprop_client/views.py
@@ -80,10 +80,13 @@ def _search_and_cache(search):
 
     # i.e if there is no cache
     if not search_results:
-        url = f"https://fuel.gazebosim.org/1.0/models?q={search}"
-        response = requests.get(url)
-        # Convert the response to a dictionary
-        search_results = response.json()
+        fuel_search_results = {}
+        blendkit_search_results = {}
+        # Search Fuel
+        fuel_url = f"https://fuel.gazebosim.org/1.0/models?q={search}"
+        fuel_response = requests.get(fuel_url)
+        fuel_search_results = fuel_response.json()
+        search_results = fuel_search_results
         # Cache the results for 5 minutes
         cache.set(cache_key, search_results, 300)
 

--- a/roboprop_client/views.py
+++ b/roboprop_client/views.py
@@ -88,14 +88,15 @@ def _search_and_cache(search):
 
     # i.e if there is no cache
     if not search_results:
-        search_results = {}
-        search_results["fuel"] = __search_external_library(
-            f"https://fuel.gazebosim.org/1.0/models?q={search}", "fuel"
-        )
-        search_results["blendkit"] = __search_external_library(
-            f"https://www.blenderkit.com/api/v1/search/?query=search+text:{search}+asset_type:model+order:_score+is_free:True&page=1",
-            "blendkit",
-        )
+        search_results = {
+            "fuel": __search_external_library(
+                f"https://fuel.gazebosim.org/1.0/models?q={search}", "fuel"
+            ),
+            "blendkit": __search_external_library(
+                f"https://www.blenderkit.com/api/v1/search/?query=search+text:{search}+asset_type:model+order:_score+is_free:True&page=1",
+                "blendkit",
+            ),
+        }
         # Cache the results for 5 minutes
         cache.set(cache_key, search_results, 300)
 
@@ -184,6 +185,7 @@ def __add_fuel_model_to_my_models(name, owner):
     return response
 
 
+# TODO: Convert blendkit model to SDF
 def __add_blendkit_model_to_my_models(thumbnail):
     url = f"models/"
     parameters = f"?url={thumbnail}"

--- a/roboprop_client/views.py
+++ b/roboprop_client/views.py
@@ -102,15 +102,6 @@ def _search_and_cache(search):
     return search_results
 
 
-def _get_fuel_model_details(result):
-    thumbnail_url = result.get("thumbnail_url", None)
-    return {
-        "name": result["name"],
-        "owner": result["owner"],
-        "thumbnail": thumbnail_url,
-    }
-
-
 def __remove_outliers_and_sort(items):
     # Remove single occurences as is most likely an outlier
     items = [item for item in items if items.count(item) > 1]
@@ -166,11 +157,22 @@ def _get_suggested_tags(thumbnails):
     colors = __remove_outliers_and_sort(colors)
 
     return tags, categories, colors
+
+
 def _get_blendkit_model_details(result):
     return {
         "name": result["name"],
         "thumbnail": result["thumbnailMiddleUrl"],
         "assetBaseId": result["assetBaseId"],
+    }
+
+
+def _get_fuel_model_details(result):
+    thumbnail_url = result.get("thumbnail_url", None)
+    return {
+        "name": result["name"],
+        "owner": result["owner"],
+        "thumbnail": thumbnail_url,
     }
 
 

--- a/roboprop_client/views.py
+++ b/roboprop_client/views.py
@@ -176,6 +176,14 @@ def _get_fuel_model_details(result):
     }
 
 
+def __add_fuel_model_to_my_models(request, name, owner):
+    # make a POST Request to our fileserver
+    url = f"models/{name}/"
+    parameters = f"?url=https://fuel.gazebosim.org/1.0/{owner}/models/{name}.zip&extract=true&clean=true"
+    response = utils.make_post_request(url, parameters=parameters)
+    return response
+
+
 """VIEWS"""
 
 
@@ -334,12 +342,13 @@ def find_models(request):
 
 def add_to_my_models(request):
     if request.method == "POST":
-        name = request.POST.get("name")
-        owner = request.POST.get("owner")
-        # make a POST Request to our fileserver
-        url = f"models/{name}/"
-        parameters = f"?url=https://fuel.gazebosim.org/1.0/{owner}/models/{name}.zip&extract=true&clean=true"
-        response = utils.make_post_request(url, parameters=parameters)
+        if request.POST.get("library") == "fuel":
+            name = request.POST.get("name")
+            owner = request.POST.get("owner")
+            response = __add_fuel_model_to_my_models(request, name, owner)
+        elif request.POST.get("library") == "blendkit":
+            # Do stuff
+            pass
         if response.status_code == 201:
             response_data = {"message": f"Success: Model: {name} added to My Models"}
         else:

--- a/roboprop_client/views.py
+++ b/roboprop_client/views.py
@@ -80,20 +80,21 @@ def _search_and_cache(search):
 
     # i.e if there is no cache
     if not search_results:
+        search_results = {}
         fuel_search_results = {}
         blendkit_search_results = {}
         # Search Fuel
         fuel_url = f"https://fuel.gazebosim.org/1.0/models?q={search}"
         fuel_response = requests.get(fuel_url)
         fuel_search_results = fuel_response.json()
-        search_results = fuel_search_results
+        search_results["fuel"] = fuel_search_results
         # Cache the results for 5 minutes
         cache.set(cache_key, search_results, 300)
 
     return search_results
 
 
-def _get_model_details(result):
+def _get_fuel_model_details(result):
     thumbnail_url = result.get("thumbnail_url", None)
     return {
         "name": result["name"],
@@ -295,18 +296,18 @@ def mymodel_detail(request, name):
 def find_models(request):
     # Check if there is a search query via GET
     search = request.GET.get("search", "")
-    models = []
+    fuel_models = []
 
     if search:
         search_results = _search_and_cache(search)
 
-        for result in search_results:
-            model_details = _get_model_details(result)
-            models.append(model_details)
+        for result in search_results["fuel"]:
+            fuel_model_details = _get_fuel_model_details(result)
+            fuel_models.append(fuel_model_details)
 
     context = {
         "search": search,
-        "models": models,
+        "fuel_models": fuel_models,
     }
 
     return render(request, "find-models.html", context=context)

--- a/roboprop_client/views.py
+++ b/roboprop_client/views.py
@@ -111,7 +111,6 @@ def _get_fuel_model_details(result):
     }
 
 
-<<<<<<< HEAD
 def __remove_outliers_and_sort(items):
     # Remove single occurences as is most likely an outlier
     items = [item for item in items if items.count(item) > 1]
@@ -167,14 +166,12 @@ def _get_suggested_tags(thumbnails):
     colors = __remove_outliers_and_sort(colors)
 
     return tags, categories, colors
-=======
 def _get_blendkit_model_details(result):
     return {
         "name": result["name"],
         "thumbnail": result["thumbnailMiddleUrl"],
         "assetBaseId": result["assetBaseId"],
     }
->>>>>>> 43f2df8 (display blendkit results in browser)
 
 
 """VIEWS"""

--- a/roboprop_client/views.py
+++ b/roboprop_client/views.py
@@ -115,6 +115,7 @@ def _get_fuel_model_details(result):
     }
 
 
+<<<<<<< HEAD
 def __remove_outliers_and_sort(items):
     # Remove single occurences as is most likely an outlier
     items = [item for item in items if items.count(item) > 1]
@@ -170,6 +171,14 @@ def _get_suggested_tags(thumbnails):
     colors = __remove_outliers_and_sort(colors)
 
     return tags, categories, colors
+=======
+def _get_blendkit_model_details(result):
+    return {
+        "name": result["name"],
+        "thumbnail": result["thumbnailMiddleUrl"],
+        "assetBaseId": result["assetBaseId"],
+    }
+>>>>>>> 43f2df8 (display blendkit results in browser)
 
 
 """VIEWS"""

--- a/roboprop_client/views.py
+++ b/roboprop_client/views.py
@@ -107,7 +107,6 @@ def _get_fuel_model_details(result):
     return {
         "name": result["name"],
         "owner": result["owner"],
-        "description": result["description"],
         "thumbnail": thumbnail_url,
     }
 

--- a/roboprop_client/views.py
+++ b/roboprop_client/views.py
@@ -176,10 +176,17 @@ def _get_fuel_model_details(result):
     }
 
 
-def __add_fuel_model_to_my_models(request, name, owner):
+def __add_fuel_model_to_my_models(name, owner):
     # make a POST Request to our fileserver
     url = f"models/{name}/"
     parameters = f"?url=https://fuel.gazebosim.org/1.0/{owner}/models/{name}.zip&extract=true&clean=true"
+    response = utils.make_post_request(url, parameters=parameters)
+    return response
+
+
+def __add_blendkit_model_to_my_models(thumbnail):
+    url = f"models/"
+    parameters = f"?url={thumbnail}"
     response = utils.make_post_request(url, parameters=parameters)
     return response
 
@@ -342,13 +349,13 @@ def find_models(request):
 
 def add_to_my_models(request):
     if request.method == "POST":
+        name = request.POST.get("name")
         if request.POST.get("library") == "fuel":
-            name = request.POST.get("name")
             owner = request.POST.get("owner")
-            response = __add_fuel_model_to_my_models(request, name, owner)
+            response = __add_fuel_model_to_my_models(name, owner)
         elif request.POST.get("library") == "blendkit":
-            # Do stuff
-            pass
+            thumbnail = request.POST.get("thumbnail")
+            response = __add_blendkit_model_to_my_models(thumbnail)
         if response.status_code == 201:
             response_data = {"message": f"Success: Model: {name} added to My Models"}
         else:

--- a/roboprop_client/views.py
+++ b/roboprop_client/views.py
@@ -83,7 +83,7 @@ def __search_fuel(search):
 def __search_blendkit(search):
     blendkit_url = f"https://www.blenderkit.com/api/v1/search/?query=search+text:{search}+asset_type:model+order:_score+is_free:True&page=1"
     blendkit_response = requests.get(blendkit_url)
-    blendkit_search_results = blendkit_response.json()
+    blendkit_search_results = blendkit_response.json()["results"]
     return blendkit_search_results
 
 
@@ -95,8 +95,6 @@ def _search_and_cache(search):
     # i.e if there is no cache
     if not search_results:
         search_results = {}
-        fuel_search_results = {}
-        blendkit_search_results = {}
         # Search Fuel
         search_results["fuel"] = __search_fuel(search)
         # Search BlendKit
@@ -310,6 +308,7 @@ def find_models(request):
     # Check if there is a search query via GET
     search = request.GET.get("search", "")
     fuel_models = []
+    blendkit_models = []
 
     if search:
         search_results = _search_and_cache(search)
@@ -318,11 +317,14 @@ def find_models(request):
             fuel_model_details = _get_fuel_model_details(result)
             fuel_models.append(fuel_model_details)
 
+        for result in search_results["blendkit"]:
+            blendkit_model_details = _get_blendkit_model_details(result)
+            blendkit_models.append(blendkit_model_details)
     context = {
         "search": search,
         "fuel_models": fuel_models,
+        "blendkit_models": blendkit_models,
     }
-
     return render(request, "find-models.html", context=context)
 
 

--- a/templates/find-models.html
+++ b/templates/find-models.html
@@ -27,9 +27,31 @@
                 </div>
             {% endfor %}
         </div>
+    {% else %}
+        <p class="m-3">No models found for search term: {{ search }} from fuel </p>
+    {% endif %}
+    {% if blendkit_models %}
+        <p class="m-3">Found {{ blendkit_models|length }} models from Blendkit using search term: {{ search }}</p>
+        <div id="notification" class="hidden font-bold px-4 py-2 rounded-md text-white w-2/3 my-2">
+        </div>
+        <div class="grid grid-cols-2 md:grid-cols-3 gap-4" id="fuel-gallery">
+            {% for model in blendkit_models %}
+                <div class="flex flex-col items-center shadow shadow-action/50 relative">
+                    <p class="cursor-pointer absolute top-0 right-0 bg-white shadow-md px-2 py-1 m-1 bg-action/80" onClick="addToMyModels('{{ model.name }}', '{{ model.assetBaseId }}')">+</p>
+                    <div class="mb-2">
+                        <img class="h-44 w-auto max-w-full rounded-lg" src="{% if model.thumbnail %}{{ model.thumbnail }}{% else %}/static/images/placeholder.png{% endif %}">
+                    </div>
+                    <div class="mb-2">
+                        <p class="text-xs">{{ model.name }}</p>
+                    </div>
+                </div>
+            {% endfor %}
+        </div>
+    {% else %}
+        <p class="m-3">No models found for search term: {{ search }} from Blendkit </p>
     {% endif %}
 
-    {% if search and not fuel_models %}
+    {% if search and not fuel_models and not blendkit_models %}
         <p class="m-3">No models found for search term: {{ search }} </p>
     {% endif %}
     

--- a/templates/find-models.html
+++ b/templates/find-models.html
@@ -22,7 +22,7 @@
                         <img class="h-44 w-auto max-w-full rounded-lg" src="{% if model.thumbnail %}https://fuel.gazebosim.org/1.0/{{ model.thumbnail }}{% else %}/static/images/placeholder.png{% endif %}">
                     </div>
                     <div class="mb-2">
-                        <p class="text-xs">{{ fuel_model.name }}</p>
+                        <p class="text-xs">{{ model.name }}</p>
                     </div>
                 </div>
             {% endfor %}

--- a/templates/find-models.html
+++ b/templates/find-models.html
@@ -10,26 +10,26 @@
         </form>
     </div>
 
-    {% if models %}
-        <p class="m-3">Found {{ models|length }} models using search term: {{ search }}</p>
+    {% if fuel_models %}
+        <p class="m-3">Found {{ fuel_models|length }} models from fuel using search term: {{ search }}</p>
         <div id="notification" class="hidden font-bold px-4 py-2 rounded-md text-white w-2/3 my-2">
         </div>
         <div class="grid grid-cols-2 md:grid-cols-3 gap-4" id="fuel-gallery">
-            {% for model in models %}
+            {% for model in fuel_models %}
                 <div class="flex flex-col items-center shadow shadow-action/50 relative">
                     <p class="cursor-pointer absolute top-0 right-0 bg-white shadow-md px-2 py-1 m-1 bg-action/80" onClick="addToMyModels('{{ model.name }}', '{{ model.owner }}')">+</p>
                     <div class="mb-2">
                         <img class="h-44 w-auto max-w-full rounded-lg" src="{% if model.thumbnail %}https://fuel.gazebosim.org/1.0/{{ model.thumbnail }}{% else %}/static/images/placeholder.png{% endif %}">
                     </div>
                     <div class="mb-2">
-                        <p class="text-xs">{{ model.name }}</p>
+                        <p class="text-xs">{{ fuel_model.name }}</p>
                     </div>
                 </div>
             {% endfor %}
         </div>
     {% endif %}
 
-    {% if search and not models %}
+    {% if search and not fuel_models %}
         <p class="m-3">No models found for search term: {{ search }} </p>
     {% endif %}
     

--- a/templates/find-models.html
+++ b/templates/find-models.html
@@ -37,7 +37,7 @@
         <div class="grid grid-cols-2 md:grid-cols-3 gap-4" id="fuel-gallery">
             {% for model in blendkit_models %}
                 <div class="flex flex-col items-center shadow shadow-action/50 relative">
-                    <p class="cursor-pointer absolute top-0 right-0 bg-white shadow-md px-2 py-1 m-1 bg-action/80" onClick="addBlendKitModel('{{ model.name }}', '{{ model.assetBaseId }}')">+</p>
+                    <p class="cursor-pointer absolute top-0 right-0 bg-white shadow-md px-2 py-1 m-1 bg-action/80" onClick="addBlendKitModel('{{ model.name }}', '{{ model.assetBaseId }}', '{{ model.thumbnail }}')">+</p>
                     <div class="mb-2">
                         <img class="h-44 w-auto max-w-full rounded-lg" src="{% if model.thumbnail %}{{ model.thumbnail }}{% else %}/static/images/placeholder.png{% endif %}">
                     </div>
@@ -92,10 +92,11 @@
             
         }
 
-        function addBlendKitModel(name, assetBaseId) {
+        function addBlendKitModel(name, assetBaseId, thumbnail) {
             const data = {
                 'name': name,
                 'assetBaseId': assetBaseId,
+                'thumbnail': thumbnail,
                 'library': 'blendkit',
                 'csrfmiddlewaretoken': '{{ csrf_token }}'
             };

--- a/templates/find-models.html
+++ b/templates/find-models.html
@@ -17,7 +17,7 @@
         <div class="grid grid-cols-2 md:grid-cols-3 gap-4" id="fuel-gallery">
             {% for model in fuel_models %}
                 <div class="flex flex-col items-center shadow shadow-action/50 relative">
-                    <p class="cursor-pointer absolute top-0 right-0 bg-white shadow-md px-2 py-1 m-1 bg-action/80" onClick="addToMyModels('{{ model.name }}', '{{ model.owner }}')">+</p>
+                    <p class="cursor-pointer absolute top-0 right-0 bg-white shadow-md px-2 py-1 m-1 bg-action/80" onClick="addFuelModel('{{ model.name }}', '{{ model.owner }}')">+</p>
                     <div class="mb-2">
                         <img class="h-44 w-auto max-w-full rounded-lg" src="{% if model.thumbnail %}https://fuel.gazebosim.org/1.0/{{ model.thumbnail }}{% else %}/static/images/placeholder.png{% endif %}">
                     </div>
@@ -37,7 +37,7 @@
         <div class="grid grid-cols-2 md:grid-cols-3 gap-4" id="fuel-gallery">
             {% for model in blendkit_models %}
                 <div class="flex flex-col items-center shadow shadow-action/50 relative">
-                    <p class="cursor-pointer absolute top-0 right-0 bg-white shadow-md px-2 py-1 m-1 bg-action/80" onClick="addToMyModels('{{ model.name }}', '{{ model.assetBaseId }}')">+</p>
+                    <p class="cursor-pointer absolute top-0 right-0 bg-white shadow-md px-2 py-1 m-1 bg-action/80" onClick="addBlendKitModel('{{ model.name }}', '{{ model.assetBaseId }}')">+</p>
                     <div class="mb-2">
                         <img class="h-44 w-auto max-w-full rounded-lg" src="{% if model.thumbnail %}{{ model.thumbnail }}{% else %}/static/images/placeholder.png{% endif %}">
                     </div>
@@ -56,12 +56,7 @@
     {% endif %}
     
     <script>
-        function addToMyModels(name, owner) {
-            const data = {
-                'name': name,
-                'owner': owner,
-                'csrfmiddlewaretoken': '{{ csrf_token }}'
-            };
+        function addModel(data) {
             const notification = document.querySelector('#notification');
             notification.innerHTML = '';
             if (!notification.classList.contains('hidden')) {
@@ -84,6 +79,27 @@
                     notification.classList.add('bg-red-500/80');
                 },
             });
+        }
+
+        function addFuelModel(name, owner) {
+            const data = {
+                'name': name,
+                'owner': owner,
+                'library': 'fuel',
+                'csrfmiddlewaretoken': '{{ csrf_token }}'
+            };
+            addModel(data);
+            
+        }
+
+        function addBlendKitModel(name, assetBaseId) {
+            const data = {
+                'name': name,
+                'assetBaseId': assetBaseId,
+                'library': 'blendkit',
+                'csrfmiddlewaretoken': '{{ csrf_token }}'
+            };
+            addModel(data);
         }
     </script>
 {% endblock %}


### PR DESCRIPTION
Relates to #31 and separates into  two stages for PR readability

1. To search and return results on blendkit, with boilerplate in place for upload (This PR)
2. Bring in @azazdeaz work on sdf conversion for the models (coming up)

This PR uses the blendkit API to search for models, and them together with the preexisting Fuel models, and then (for now) just uploads the thumbnail of it to the server. This part will change to run the blender / sdf conversion logic. 

![image](https://github.com/art-e-fact/RoboProp/assets/68368403/4511c017-7eed-47fc-bb6f-0bdd337c2454)
