### PR TITLE
Use Blender directly instead of blenderproc

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,3 @@ python-dotenv
 requests
 xmltodict
 boto3
-blenderproc

--- a/roboprop_client/blender_scripts/export_glb.py
+++ b/roboprop_client/blender_scripts/export_glb.py
@@ -1,0 +1,25 @@
+import bpy
+from pathlib import Path
+import argparse
+import sys
+
+parser = argparse.ArgumentParser()
+parser.add_argument('-o', '--output', dest='output', required=True)
+
+
+if '--' in sys.argv:
+    argv = sys.argv[sys.argv.index('--') + 1:]
+else:
+    argv = []
+args = parser.parse_known_args(argv)[0]
+
+bpy.ops.export_scene.gltf(
+    filepath=args.output,
+    check_existing=False,
+    use_selection=False,
+    export_materials="EXPORT",
+    export_format="GLB",
+    export_image_format="JPEG",
+    export_jpeg_quality=88,
+)
+

--- a/roboprop_client/blender_scripts/export_glb.py
+++ b/roboprop_client/blender_scripts/export_glb.py
@@ -4,11 +4,11 @@ import argparse
 import sys
 
 parser = argparse.ArgumentParser()
-parser.add_argument('-o', '--output', dest='output', required=True)
+parser.add_argument("-o", "--output", dest="output", required=True)
 
 
-if '--' in sys.argv:
-    argv = sys.argv[sys.argv.index('--') + 1:]
+if "--" in sys.argv:
+    argv = sys.argv[sys.argv.index("--") + 1 :]
 else:
     argv = []
 args = parser.parse_known_args(argv)[0]
@@ -22,4 +22,3 @@ bpy.ops.export_scene.gltf(
     export_image_format="JPEG",
     export_jpeg_quality=88,
 )
-

--- a/roboprop_client/blender_scripts/export_obj.py
+++ b/roboprop_client/blender_scripts/export_obj.py
@@ -1,0 +1,31 @@
+import bpy
+from pathlib import Path
+import argparse
+import sys
+import os
+
+parser = argparse.ArgumentParser()
+parser.add_argument('-o', '--output', dest='output', required=True)
+
+
+if '--' in sys.argv:
+    argv = sys.argv[sys.argv.index('--') + 1:]
+else:
+    argv = []
+args = parser.parse_known_args(argv)[0]
+output = Path(args.output)
+
+bpy.ops.file.unpack_all(method="USE_LOCAL")
+
+bpy.ops.export_scene.obj(
+    filepath=args.output,
+    check_existing=False,
+    # Use ROS coordinate frame
+    axis_forward="Y",
+    axis_up="Z",
+    use_selection=False,
+    use_materials=True,
+    use_triangles=True,
+    # copy all the texture images next to the model
+    path_mode="COPY",
+)

--- a/roboprop_client/blender_scripts/export_obj.py
+++ b/roboprop_client/blender_scripts/export_obj.py
@@ -5,11 +5,11 @@ import sys
 import os
 
 parser = argparse.ArgumentParser()
-parser.add_argument('-o', '--output', dest='output', required=True)
+parser.add_argument("-o", "--output", dest="output", required=True)
 
 
-if '--' in sys.argv:
-    argv = sys.argv[sys.argv.index('--') + 1:]
+if "--" in sys.argv:
+    argv = sys.argv[sys.argv.index("--") + 1 :]
 else:
     argv = []
 args = parser.parse_known_args(argv)[0]

--- a/roboprop_client/export_model.py
+++ b/roboprop_client/export_model.py
@@ -80,7 +80,7 @@ def export_sdf(path_model: Path, model_name: str, blend_file_path: str):
                 "blender",
                 blend_file_path,
                 "--background",
-                "--factory-startup", 
+                "--factory-startup",
                 "--python",
                 Path(__file__).parent / "blender_scripts" / export_script,
                 "--",
@@ -92,7 +92,7 @@ def export_sdf(path_model: Path, model_name: str, blend_file_path: str):
                 print(result.stdout)
             if result.stderr:
                 print(result.stderr)
-            
+
         for path_visual in visual_paths:
             os.makedirs(name=os.path.dirname(path_visual), exist_ok=True)
             if Path(path_visual).suffix == ".obj":

--- a/roboprop_client/load_blenderkit.py
+++ b/roboprop_client/load_blenderkit.py
@@ -90,6 +90,7 @@ def add_demo_world(model_path: Path):
 
     return demo_path
 
+
 def load_blenderkit_model(asset_base_id: str, output_path: str, model_name: str = None):
     # Load asset meta data from BlenderKit
     meta = load_asset_meta(asset_base_id)
@@ -113,8 +114,6 @@ def load_blenderkit_model(asset_base_id: str, output_path: str, model_name: str 
 
 
 def main(args):
-    
-
     load_blenderkit_model(args.asset_base_id, args.output_path, args.model_name)
 
 

--- a/roboprop_client/load_blenderkit.py
+++ b/roboprop_client/load_blenderkit.py
@@ -1,5 +1,3 @@
-import blenderproc as bproc
-import bpy
 import uuid
 from pathlib import Path
 import requests
@@ -92,22 +90,19 @@ def add_demo_world(model_path: Path):
 
     return demo_path
 
-
-def main(args):
-    # Start a clean Blender proceess
-    bproc.init()
-
+def load_blenerkit_model(asset_base_id: str, output_path: str, model_name: str = None):
     # Load asset meta data from BlenderKit
-    meta = load_asset_meta(args.asset_base_id)
+    meta = load_asset_meta(asset_base_id)
 
-    if not args.model_name:
-        args.model_name = meta["name"]
+    if not model_name:
+        model_name = meta["name"]
 
     blend_file = load_model_from_blenderkit(meta)
-    model_path = Path(args.output_path) / args.model_name
-    objs = bproc.loader.load_blend(blend_file)
-    bpy.ops.file.unpack_all(method="USE_LOCAL")
-    export_sdf(model_path, args.model_name)
+    model_path = Path(output_path) / model_name
+    # objs = bproc.loader.load_blend(blend_file)
+    # bpy.ops.wm.open_mainfile(filepath=blend_file)
+    # bpy.ops.file.unpack_all(method="USE_LOCAL")
+    export_sdf(model_path, model_name, blend_file)
 
     # Save meta data in the model folder
     meta_path = model_path / "blenderkit_meta.json"
@@ -117,12 +112,18 @@ def main(args):
     demo_path = add_demo_world(model_path)
 
 
+def main(args):
+    
+
+    load_blenerkit_model(args.asset_base_id, args.output_path, args.model_name)
+
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         description="""
         CLI app for converting BlenderKit models to (Gazebo) SDF
         Example usage:
-          blenderproc run load.py --asset_base_id 42f9e34f-f817-4505-b000-f86be1a68c8b --output_path models --model_name StrangeChair
+          python roboprop_client/load_blenderkit.py --asset_base_id 42f9e34f-f817-4505-b000-f86be1a68c8b --output_path models --model_name StrangeChair
         """
     )
 

--- a/roboprop_client/load_blenderkit.py
+++ b/roboprop_client/load_blenderkit.py
@@ -90,7 +90,7 @@ def add_demo_world(model_path: Path):
 
     return demo_path
 
-def load_blenerkit_model(asset_base_id: str, output_path: str, model_name: str = None):
+def load_blenderkit_model(asset_base_id: str, output_path: str, model_name: str = None):
     # Load asset meta data from BlenderKit
     meta = load_asset_meta(asset_base_id)
 
@@ -115,7 +115,7 @@ def load_blenerkit_model(asset_base_id: str, output_path: str, model_name: str =
 def main(args):
     
 
-    load_blenerkit_model(args.asset_base_id, args.output_path, args.model_name)
+    load_blenderkit_model(args.asset_base_id, args.output_path, args.model_name)
 
 
 if __name__ == "__main__":

--- a/roboprop_client/urls.py
+++ b/roboprop_client/urls.py
@@ -15,4 +15,9 @@ urlpatterns = [
     path("register", views.register, name="register"),
     path("settings/", views.user_settings, name="user_settings"),
     path("add-metadata/<str:name>/", views.add_metadata, name="add_metadata"),
+    path(
+        "update-models-from-blendkit/",
+        views.update_models_from_blendkit,
+        name="update_models_from_blendkit",
+    ),
 ]

--- a/roboprop_client/views.py
+++ b/roboprop_client/views.py
@@ -16,7 +16,7 @@ from django.contrib.auth.models import User
 from django.contrib.auth.decorators import login_required
 from django.contrib import messages
 from django.contrib.auth import update_session_auth_hash
-from roboprop_client.load_blenderkit import load_blenerkit_model
+from roboprop_client.load_blenderkit import load_blenderkit_model
 import roboprop_client.utils as utils
 
 
@@ -221,7 +221,7 @@ def __add_blendkit_thumbnail(thumbnail, folder_name):
 
 
 def __add_blendkit_model_to_my_models(folder_name, asset_base_id, thumbnail):
-    load_blenerkit_model(asset_base_id, "models", folder_name)
+    load_blenderkit_model(asset_base_id, "models", folder_name)
 
     __add_blendkit_thumbnail(thumbnail, folder_name)
     zip_filename, zip_path = utils.create_zip_file(folder_name)

--- a/templates/mymodels.html
+++ b/templates/mymodels.html
@@ -5,8 +5,15 @@
 {% block content %}
     <h2 class="text-2xl text-center">My Models</h2>
     {% include "components/_message_block.html" %}
-    {% include "components/_upload_modal.html" %}
+    <div class="flex space-x-4">
+        {% include "components/_upload_modal.html" %}
+        <button class="block text-white bg-action/80 hover:bg-action focus:ring-4 focus:outline-none focus:ring-blue-300 font-medium rounded-lg text-sm px-5 py-2.5 text-center" type="button" onClick="updateBlendkitModels()">
+            Update Blendkit Models
+        </button>
+    </div>
     {% include "components/_category_block.html" %}
+    <div id="notification" class="hidden font-bold px-4 py-2 rounded-md text-white w-2/3 my-2">
+    </div>
     <div class="grid grid-cols-2 md:grid-cols-3 gap-4">
         {% for thumbnail in thumbnails %}
         <a href="{% url 'mymodel_detail' name=thumbnail.name %}">
@@ -21,4 +28,37 @@
         </a>
         {% endfor %}
     </div>
+
+    <script>
+        function updateBlendkitModels() {
+            const notification = document.querySelector('#notification');
+            notification.innerHTML = '';
+            if (!notification.classList.contains('hidden')) {
+                notification.classList.add('hidden');
+            }
+            const data = {
+                csrfmiddlewaretoken: '{{ csrf_token }}',
+            };
+            notification.innerHTML = 'Updating Blendkit Models, this may take a while...';
+            notification.classList.remove('hidden');
+            notification.classList.add('bg-blue-500/80');
+            notification.classList.remove('bg-green-500/80');
+            notification.classList.remove('bg-red-500/80');
+            $.ajax({
+                url: '/update-models-from-blendkit/',
+                type: 'POST',
+                data: data,
+                success: function(response) {
+                    notification.innerHTML = response.message;
+                    notification.classList.remove('bg-blue-500/80');
+                    notification.classList.add('bg-green-500/80');
+                },
+                error: function(error) {
+                    notification.innerHTML = error.responseJSON.error;
+                    notification.classList.remove('bg-blue-500/80');
+                    notification.classList.add('bg-red-500/80');
+                },
+            });
+        }
+    </script>
 {% endblock %}


### PR DESCRIPTION
Originally, i used blenderproc because it seemed like a convenient way to install and call Blender. Unfortunately it doesn't work with new versions of Blender and has some other issues so in this PR:
 - use Blender directly instead of blenderproc (this requires a `blender` executable on the PATH but we can change that. Let me know what works best at the production environment)
 - minimizes the use of blender specific scripts, so the generation part is not that separated from the rest of the app
 - optimizes the textures in the .gbl exports. this is just a first step, there is a lot more thing we can optimize to make the models smaller
 
 I leave this as a draft until we have a chance to discuss it.