### PR TITLE
Rerun blenderkit conversions

### DIFF
--- a/roboprop_client/load_blenderkit.py
+++ b/roboprop_client/load_blenderkit.py
@@ -91,7 +91,11 @@ def add_demo_world(model_path: Path):
     return demo_path
 
 
+<<<<<<< HEAD
 def load_blenderkit_model(asset_base_id: str, output_path: str, model_name: str = None):
+=======
+def load_blenerkit_model(asset_base_id: str, output_path: str, model_name: str = None):
+>>>>>>> 1b6ed9e (Allow reconversion of all current blendkit models)
     # Load asset meta data from BlenderKit
     meta = load_asset_meta(asset_base_id)
 
@@ -114,7 +118,11 @@ def load_blenderkit_model(asset_base_id: str, output_path: str, model_name: str 
 
 
 def main(args):
+<<<<<<< HEAD
     load_blenderkit_model(args.asset_base_id, args.output_path, args.model_name)
+=======
+    load_blenerkit_model(args.asset_base_id, args.output_path, args.model_name)
+>>>>>>> 1b6ed9e (Allow reconversion of all current blendkit models)
 
 
 if __name__ == "__main__":

--- a/roboprop_client/load_blenderkit.py
+++ b/roboprop_client/load_blenderkit.py
@@ -91,11 +91,7 @@ def add_demo_world(model_path: Path):
     return demo_path
 
 
-<<<<<<< HEAD
 def load_blenderkit_model(asset_base_id: str, output_path: str, model_name: str = None):
-=======
-def load_blenerkit_model(asset_base_id: str, output_path: str, model_name: str = None):
->>>>>>> 1b6ed9e (Allow reconversion of all current blendkit models)
     # Load asset meta data from BlenderKit
     meta = load_asset_meta(asset_base_id)
 
@@ -118,11 +114,7 @@ def load_blenerkit_model(asset_base_id: str, output_path: str, model_name: str =
 
 
 def main(args):
-<<<<<<< HEAD
     load_blenderkit_model(args.asset_base_id, args.output_path, args.model_name)
-=======
-    load_blenerkit_model(args.asset_base_id, args.output_path, args.model_name)
->>>>>>> 1b6ed9e (Allow reconversion of all current blendkit models)
 
 
 if __name__ == "__main__":

--- a/roboprop_client/urls.py
+++ b/roboprop_client/urls.py
@@ -15,4 +15,9 @@ urlpatterns = [
     path("register", views.register, name="register"),
     path("settings/", views.user_settings, name="user_settings"),
     path("add-metadata/<str:name>/", views.add_metadata, name="add_metadata"),
+    path(
+        "update-models-from-blendkit/",
+        views.update_models_from_blendkit,
+        name="update_models_from_blendkit",
+    ),
 ]

--- a/templates/mymodels.html
+++ b/templates/mymodels.html
@@ -6,7 +6,12 @@
     <h2 class="text-2xl text-center">My Models</h2>
     {% include "components/_message_block.html" %}
     {% include "components/_upload_modal.html" %}
+    <button class="block text-white bg-action/80 hover:bg-action focus:ring-4 focus:outline-none focus:ring-blue-300 font-medium rounded-lg text-sm px-5 py-2.5 text-center" type="button" onClick="updateBlendkitModels()">
+        Update Blendkit Models
+    </button>
     {% include "components/_category_block.html" %}
+    <div id="notification" class="hidden font-bold px-4 py-2 rounded-md text-white w-2/3 my-2">
+    </div>
     <div class="grid grid-cols-2 md:grid-cols-3 gap-4">
         {% for thumbnail in thumbnails %}
         <a href="{% url 'mymodel_detail' name=thumbnail.name %}">
@@ -21,4 +26,35 @@
         </a>
         {% endfor %}
     </div>
+
+    <script>
+        function updateBlendkitModels() {
+            const notification = document.querySelector('#notification');
+            notification.innerHTML = '';
+            if (!notification.classList.contains('hidden')) {
+                notification.classList.add('hidden');
+            }
+            const data = {
+                csrfmiddlewaretoken: '{{ csrf_token }}',
+            };
+            $.ajax({
+                url: '/update-models-from-blendkit/',
+                type: 'POST',
+                data: data,
+                success: function(response) {
+                    notification.innerHTML = response.message;
+                    notification.classList.remove('hidden');
+                    notification.classList.remove('bg-red-500/80');
+                    notification.classList.add('bg-green-500/80');
+                },
+                error: function(error) {
+                    notification.innerHTML = error.responseJSON.error;
+                    notification.classList.remove('hidden');
+                    notification.classList.remove('bg-green-500/80');
+                    notification.classList.add('bg-red-500/80');
+                },
+            });
+        }
+
+    </script>
 {% endblock %}

--- a/templates/mymodels.html
+++ b/templates/mymodels.html
@@ -5,10 +5,12 @@
 {% block content %}
     <h2 class="text-2xl text-center">My Models</h2>
     {% include "components/_message_block.html" %}
-    {% include "components/_upload_modal.html" %}
-    <button class="block text-white bg-action/80 hover:bg-action focus:ring-4 focus:outline-none focus:ring-blue-300 font-medium rounded-lg text-sm px-5 py-2.5 text-center" type="button" onClick="updateBlendkitModels()">
-        Update Blendkit Models
-    </button>
+    <div class="flex space-x-4">
+        {% include "components/_upload_modal.html" %}
+        <button class="block text-white bg-action/80 hover:bg-action focus:ring-4 focus:outline-none focus:ring-blue-300 font-medium rounded-lg text-sm px-5 py-2.5 text-center" type="button" onClick="updateBlendkitModels()">
+            Update Blendkit Models
+        </button>
+    </div>
     {% include "components/_category_block.html" %}
     <div id="notification" class="hidden font-bold px-4 py-2 rounded-md text-white w-2/3 my-2">
     </div>
@@ -37,24 +39,26 @@
             const data = {
                 csrfmiddlewaretoken: '{{ csrf_token }}',
             };
+            notification.innerHTML = 'Updating Blendkit Models, this may take a while...';
+            notification.classList.remove('hidden');
+            notification.classList.add('bg-blue-500/80');
+            notification.classList.remove('bg-green-500/80');
+            notification.classList.remove('bg-red-500/80');
             $.ajax({
                 url: '/update-models-from-blendkit/',
                 type: 'POST',
                 data: data,
                 success: function(response) {
                     notification.innerHTML = response.message;
-                    notification.classList.remove('hidden');
-                    notification.classList.remove('bg-red-500/80');
+                    notification.classList.remove('bg-blue-500/80');
                     notification.classList.add('bg-green-500/80');
                 },
                 error: function(error) {
                     notification.innerHTML = error.responseJSON.error;
-                    notification.classList.remove('hidden');
-                    notification.classList.remove('bg-green-500/80');
+                    notification.classList.remove('bg-blue-500/80');
                     notification.classList.add('bg-red-500/80');
                 },
             });
         }
-
     </script>
 {% endblock %}


### PR DESCRIPTION
Basically an "Optimize!" button which will go through every model originally from blendkit and rerun the conversion process _while keeping the original index.json_ (in case of any manual curation). This is so it can be run when the blendkit conversion logic has been updated / further optimized.

![image](https://github.com/art-e-fact/RoboProp/assets/68368403/4f8a4771-c077-4ea0-906f-3366af50dccb)

This should either be merged into the optimize-glb branch, or the dev branch after @azazdeaz optimize-glb PR has been merged. 