### PR TITLE
Oprimize meshes in export script

### DIFF
--- a/roboprop_client/blender_scripts/export_glb.py
+++ b/roboprop_client/blender_scripts/export_glb.py
@@ -13,6 +13,17 @@ else:
     argv = []
 args = parser.parse_known_args(argv)[0]
 
+# Add Palanar Decimate modifyer to all meshes
+angle_limit = 12.0 # merge faces within this angle
+for obj in bpy.data.objects:
+    if obj.type == "MESH":
+        bpy.context.view_layer.objects.active = obj
+        bpy.ops.object.modifier_add(type="DECIMATE")
+        modifier = bpy.context.object.modifiers[-1]
+        modifier.decimate_type = "DISSOLVE"
+        modifier.angle_limit = angle_limit / 180.0 * 3.14159
+        bpy.ops.object.modifier_apply(modifier=modifier.name)
+
 bpy.ops.export_scene.gltf(
     filepath=args.output,
     check_existing=False,
@@ -20,5 +31,5 @@ bpy.ops.export_scene.gltf(
     export_materials="EXPORT",
     export_format="GLB",
     export_image_format="JPEG",
-    export_jpeg_quality=88,
+    export_jpeg_quality=60,
 )

--- a/roboprop_client/blender_scripts/export_obj.py
+++ b/roboprop_client/blender_scripts/export_obj.py
@@ -15,6 +15,17 @@ else:
 args = parser.parse_known_args(argv)[0]
 output = Path(args.output)
 
+# Add Palanar Decimate modifyer to all meshes
+angle_limit = 12.0 # merge faces within this angle
+for obj in bpy.data.objects:
+    if obj.type == "MESH":
+        bpy.context.view_layer.objects.active = obj
+        bpy.ops.object.modifier_add(type="DECIMATE")
+        modifier = bpy.context.object.modifiers[-1]
+        modifier.decimate_type = "DISSOLVE"
+        modifier.angle_limit = angle_limit / 180.0 * 3.14159
+        bpy.ops.object.modifier_apply(modifier=modifier.name)
+
 bpy.ops.file.unpack_all(method="USE_LOCAL")
 
 bpy.ops.export_scene.obj(


### PR DESCRIPTION
Simplifies the meshes and lowers the JPEG quality in the glTF models. No huge gains, but it's better :+1: 