### PR TITLE
Improve index loading with Pagination

### DIFF
--- a/roboprop_client/blender_scripts/export_glb.py
+++ b/roboprop_client/blender_scripts/export_glb.py
@@ -14,7 +14,7 @@ else:
 args = parser.parse_known_args(argv)[0]
 
 # Add Palanar Decimate modifyer to all meshes
-angle_limit = 12.0 # merge faces within this angle
+angle_limit = 12.0  # merge faces within this angle
 for obj in bpy.data.objects:
     if obj.type == "MESH":
         bpy.context.view_layer.objects.active = obj

--- a/roboprop_client/blender_scripts/export_obj.py
+++ b/roboprop_client/blender_scripts/export_obj.py
@@ -16,7 +16,7 @@ args = parser.parse_known_args(argv)[0]
 output = Path(args.output)
 
 # Add Palanar Decimate modifyer to all meshes
-angle_limit = 12.0 # merge faces within this angle
+angle_limit = 12.0  # merge faces within this angle
 for obj in bpy.data.objects:
     if obj.type == "MESH":
         bpy.context.view_layer.objects.active = obj

--- a/roboprop_client/views.py
+++ b/roboprop_client/views.py
@@ -8,6 +8,7 @@ import urllib.parse
 import subprocess
 import zipfile
 import shutil
+import math
 from django.shortcuts import render, redirect
 from django.http import HttpResponse, JsonResponse
 from django.core.cache import cache
@@ -417,6 +418,7 @@ def mymodels(request):
             return redirect("mymodels")
 
     total_num_models = __get_num_assets("models")
+    total_pages = math.ceil(total_num_models / page_size)
     gallery_thumbnails = _get_all_thumbnails("models", page, page_size)
     return render(
         request,
@@ -426,6 +428,7 @@ def mymodels(request):
             "page": page,
             "page_size": page_size,
             "total_models": total_num_models,
+            "total_pages": total_pages,
         },
     )
 

--- a/roboprop_client/views.py
+++ b/roboprop_client/views.py
@@ -298,6 +298,13 @@ def _add_fuel_model_metadata(request, name, description):
     return response
 
 
+def __get_num_assets(asset_type):
+    assets = _get_assets(f"{asset_type}/")
+    if not assets:
+        return 0
+    return len(assets)
+
+
 """VIEWS"""
 
 
@@ -389,6 +396,8 @@ def user_settings(request):
 
 
 def mymodels(request):
+    page = int(request.GET.get("page", 1))
+    page_size = int(request.GET.get("page_size", 12))
     if request.method == "POST":
         file = request.FILES["file"]
         response = utils.upload_file(file, "models")
@@ -407,8 +416,18 @@ def mymodels(request):
             messages.error(request, "Failed to upload model")
             return redirect("mymodels")
 
-    gallery_thumbnails = _get_all_thumbnails("models")
-    return render(request, "mymodels.html", {"thumbnails": gallery_thumbnails})
+    total_num_models = __get_num_assets("models")
+    gallery_thumbnails = _get_all_thumbnails("models", page, page_size)
+    return render(
+        request,
+        "mymodels.html",
+        {
+            "thumbnails": gallery_thumbnails,
+            "page": page,
+            "page_size": page_size,
+            "total_models": total_num_models,
+        },
+    )
 
 
 def mymodel_detail(request, name):

--- a/roboprop_client/views.py
+++ b/roboprop_client/views.py
@@ -33,7 +33,10 @@ def _get_assets(url):
     return assets
 
 
-def _get_thumbnails(assets, asset_type, gallery=True):
+def _get_thumbnails(assets, asset_type, page=1, page_size=12, gallery=True):
+    start_index = (page - 1) * page_size
+    end_index = start_index + page_size
+    assets = assets[start_index:end_index]
     thumbnails = []
     for asset in assets:
         url = f"{asset_type}/{asset}/thumbnails/"
@@ -54,11 +57,11 @@ def _get_thumbnails(assets, asset_type, gallery=True):
     return thumbnails
 
 
-def _get_all_thumbnails(asset_type):
+def _get_all_thumbnails(asset_type, page=1, page_size=12):
     assets = _get_assets(f"{asset_type}/")
     if not assets:
         return []
-    thumbnails = _get_thumbnails(assets, asset_type)
+    thumbnails = _get_thumbnails(assets, asset_type, page, page_size)
     return thumbnails
 
 
@@ -238,7 +241,7 @@ def __add_blendkit_model_to_my_models(folder_name, asset_base_id, thumbnail):
 
 
 def __create_metadata_from_rekognition(name):
-    thumbnails = _get_thumbnails([name], "models", gallery=False)
+    thumbnails = _get_thumbnails([name], "models", page=1, page_size=1, gallery=False)
     tags, categories, colors = [], [], []
     if all(thumbnail["image"] is not None for thumbnail in thumbnails):
         base64_thumbnails = list(thumbnail["image"] for thumbnail in thumbnails)
@@ -415,7 +418,7 @@ def mymodel_detail(request, name):
         "configuration": {},
     }
 
-    thumbnails = _get_thumbnails([name], "models", gallery=False)
+    thumbnails = _get_thumbnails([name], "models", page=1, page_size=1, gallery=False)
 
     for thumbnail in thumbnails:
         model_details["thumbnails"].append(thumbnail["image"])
@@ -512,7 +515,7 @@ def myrobot_detail(request, name):
         "thumbnails": [],
     }
 
-    thumbnails = _get_thumbnails([name], "robots", gallery=False)
+    thumbnails = _get_thumbnails([name], "robots", page=1, page_size=1, gallery=False)
 
     for thumbnail in thumbnails:
         robot_details["thumbnails"].append(thumbnail["image"])

--- a/templates/mymodels.html
+++ b/templates/mymodels.html
@@ -33,8 +33,8 @@
           <input type="hidden" name="page_size" value="{{ page_size }}">
           <label for="page">Page:</label>
           <input type="number" name="page" id="page" value="{{ page }}" min="1" max="{{ total_pages }}" required>
-          <button type="submit" name="action" value="previous" {% if page == 1 %}disabled{% endif %}>Previous</button>
-          <button type="submit" name="action" value="next" {% if page == total_pages %}disabled{% endif %}>Next</button>
+          <button type="number" name="page" value="{{ page|add:'-1' }}" {% if page == 1 %}disabled{% endif %}>Previous</button>
+          <button type="number" name="page" value="{{ page|add:1 }}" {% if page == total_pages %}disabled{% endif %}>Next</button>
         </form>
       </div>
       <p>Page {{ page }} of {{ total_pages }} ({{ page_size }} models per page)</p>

--- a/templates/mymodels.html
+++ b/templates/mymodels.html
@@ -30,15 +30,22 @@
     </div>
     <div class="pagination">
         <form method="get">
-          <label for="page_size">Page size:</label>
-          <input type="number" name="page_size" id="page_size" value="{{ page_size }}" min="1" max="100" required>
-          <label for="page">Page:</label>
-          <input type="number" name="page" id="page" value="{{ page }}" min="1" max="{{ total_pages }}" required>
-          <button type="submit" name="page" value="{{ page|add:'-1' }}" {% if page == 1 %}disabled{% endif %}>Previous</button>
-          <button type="submit" name="page" value="{{ page|add:1 }}" {% if page == total_pages %}disabled{% endif %}>Next</button>
+            <div class="flex justify-between items-center mt-4">
+                <div>
+                  <button type="submit" name="page" value="{{ page|add:'-1' }}" class="px-3 py-2 rounded-md bg-gray-200 text-gray-700 hover:bg-gray-300 {% if page == 1 %}opacity-50 cursor-not-allowed{% endif %}">Previous</button>
+                  <span class="mx-2">Page</span>
+                  <input type="number" name="page" id="page" value="{{ page }}" min="1" max="{{ total_pages }}" class="w-16 px-2 py-1 rounded-md bg-gray-200 text-gray-700 text-center" disabled>
+                  <span class="mx-2">of {{ total_pages }}</span>
+                  <button type="submit" name="page" value="{{ page|add:1 }}" class="px-3 py-2 rounded-md bg-gray-200 text-gray-700 hover:bg-gray-300 {% if page == total_pages %}opacity-50 cursor-not-allowed{% endif %}">Next</button>
+                </div>
+                <div>
+                  <label for="page_size" class="mr-2">Models per page:</label>
+                  <input type="number" name="page_size" id="page_size" value="{{ page_size }}" min="1" max="100" class="w-16 px-2 py-1 rounded-md bg-gray-200 text-gray-700 text-center" required>
+                </div>
+              </div>
+              <p class="mt-2">Showing {{ thumbnails|length }} models ({{ total_models }} total)</p>
         </form>
       </div>
-      <p>Page {{ page }} of {{ total_pages }} ({{ page_size }} models per page)</p>
 
     <script>
         function updateBlendkitModels() {

--- a/templates/mymodels.html
+++ b/templates/mymodels.html
@@ -28,6 +28,16 @@
         </a>
         {% endfor %}
     </div>
+    <div class="pagination">
+        <form method="get">
+          <input type="hidden" name="page_size" value="{{ page_size }}">
+          <label for="page">Page:</label>
+          <input type="number" name="page" id="page" value="{{ page }}" min="1" max="{{ total_pages }}" required>
+          <button type="submit" name="action" value="previous" {% if page == 1 %}disabled{% endif %}>Previous</button>
+          <button type="submit" name="action" value="next" {% if page == total_pages %}disabled{% endif %}>Next</button>
+        </form>
+      </div>
+      <p>Page {{ page }} of {{ total_pages }} ({{ page_size }} models per page)</p>
 
     <script>
         function updateBlendkitModels() {

--- a/templates/mymodels.html
+++ b/templates/mymodels.html
@@ -30,11 +30,12 @@
     </div>
     <div class="pagination">
         <form method="get">
-          <input type="hidden" name="page_size" value="{{ page_size }}">
+          <label for="page_size">Page size:</label>
+          <input type="number" name="page_size" id="page_size" value="{{ page_size }}" min="1" max="100" required>
           <label for="page">Page:</label>
           <input type="number" name="page" id="page" value="{{ page }}" min="1" max="{{ total_pages }}" required>
-          <button type="number" name="page" value="{{ page|add:'-1' }}" {% if page == 1 %}disabled{% endif %}>Previous</button>
-          <button type="number" name="page" value="{{ page|add:1 }}" {% if page == total_pages %}disabled{% endif %}>Next</button>
+          <button type="submit" name="page" value="{{ page|add:'-1' }}" {% if page == 1 %}disabled{% endif %}>Previous</button>
+          <button type="submit" name="page" value="{{ page|add:1 }}" {% if page == total_pages %}disabled{% endif %}>Next</button>
         </form>
       </div>
       <p>Page {{ page }} of {{ total_pages }} ({{ page_size }} models per page)</p>


### PR DESCRIPTION
Adds pagination to the mymodels page, so that it doesn't take forever and a day to load in all the models.
Functionaly works (Next, previous, number of models per page), doesnt let you select which page you want yet.
And styling is basic


<img width="1345" alt="Screenshot 2023-10-05 at 14 14 26" src="https://github.com/art-e-fact/RoboProp/assets/68368403/b6e80f9e-87c6-497d-8fb1-a9cf40dcd9de">
