### PR TITLE
Dockerize Roboprop_Client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,6 +69,7 @@ venv/
 ENV/ 
 env.bak/ 
 venv.bak/ 
+.env.dev
 
 # mkdocs documentation 
 /site 

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,8 +21,11 @@ RUN apk update \
     && apk add postgresql-dev gcc python3-dev musl-dev \
     && apk del build-deps \
     && apk --no-cache add musl-dev linux-headers g++
+
+RUN apk add --update nodejs npm
 # install dependencies
 RUN pip install --upgrade pip
 # copy project
 COPY . $MICRO_SERVICE
+RUN npm install
 RUN pip install -r requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,6 @@ RUN apk add --update nodejs npm
 # install dependencies
 RUN pip install --upgrade pip
 # copy project
-COPY . $MICRO_SERVICE
+COPY . $ROBOPROP_CLIENT
 RUN npm install
 RUN pip install -r requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,15 @@
 FROM python:3.9.13-alpine
 
-ENV MICRO_SERVICE=/home/app/microservice
+ENV ROBOPROP_CLIENT=/home/app/roboprop
 RUN addgroup -S admin && adduser -S admin -G admin
 # set work directory
 
 
-RUN mkdir -p $MICRO_SERVICE
-RUN mkdir -p $MICRO_SERVICE/static
+RUN mkdir -p $ROBOPROP_CLIENT
+RUN mkdir -p $ROBOPROP_CLIENT/static
 
 # where the code lives
-WORKDIR $MICRO_SERVICE
+WORKDIR $ROBOPROP_CLIENT
 
 # set environment variables
 ENV PYTHONDONTWRITEBYTECODE 1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+FROM python:3.9.13-alpine
+
+ENV MICRO_SERVICE=/home/app/microservice
+RUN addgroup -S admin && adduser -S admin -G admin
+# set work directory
+
+
+RUN mkdir -p $MICRO_SERVICE
+RUN mkdir -p $MICRO_SERVICE/static
+
+# where the code lives
+WORKDIR $MICRO_SERVICE
+
+# set environment variables
+ENV PYTHONDONTWRITEBYTECODE 1
+ENV PYTHONUNBUFFERED 1
+
+# install psycopg2 dependencies
+RUN apk update \
+    && apk add --virtual build-deps gcc python3-dev musl-dev \
+    && apk add postgresql-dev gcc python3-dev musl-dev \
+    && apk del build-deps \
+    && apk --no-cache add musl-dev linux-headers g++
+# install dependencies
+RUN pip install --upgrade pip
+# copy project
+COPY . $MICRO_SERVICE
+RUN pip install -r requirements.txt

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,9 +4,9 @@ services:
   nginx:
     build: ./nginx
     ports:
-      - 1300:80
+      - 80:80
     volumes:
-      - static_volume:/home/app/microservice/static
+      - static_volume:/home/app/roboprop/static
     depends_on:
       - web
     restart: "on-failure"
@@ -17,8 +17,8 @@ services:
                     npx tailwindcss -i ./static/src/input.css -o ./static/src/output.css &&
                     gunicorn roboprop.wsgi:application --bind 0.0.0.0:8000"
     volumes:
-      - .:/microservice:rw # map data and files from parent directory in host to microservice directory in docker containe
-      - static_volume:/home/app/microservice/static
+      - .:/roboprop:rw # map data and files from parent directory in host to roboprop directory in docker container
+      - static_volume:/home/app/roboprop/static
     env_file:
       - .env
     image: roboprop
@@ -26,8 +26,6 @@ services:
     expose:
       - 8000
     restart: "on-failure"
-
-
 
 volumes:
   static_volume:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,33 @@
+version: '3.8'
+
+services:
+  nginx:
+    build: ./nginx
+    ports:
+      - 1300:80
+    volumes:
+      - static_volume:/home/app/microservice/static
+    depends_on:
+      - web
+    restart: "on-failure"
+  web:
+    build: . #build the image for the web service from the dockerfile in parent directory
+    command: sh -c "python manage.py makemigrations &&
+                    python manage.py migrate &&
+                    gunicorn roboprop.wsgi:application --bind 0.0.0.0:8000"
+    volumes:
+      - .:/microservice:rw # map data and files from parent directory in host to microservice directory in docker containe
+      - static_volume:/home/app/microservice/static
+    env_file:
+      - .env
+    image: roboprop
+
+    expose:
+      - 8000
+    restart: "on-failure"
+
+
+
+volumes:
+  postgres_data:
+  static_volume:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -14,6 +14,7 @@ services:
     build: . #build the image for the web service from the dockerfile in parent directory
     command: sh -c "python manage.py makemigrations &&
                     python manage.py migrate &&
+                    npx tailwindcss -i ./static/src/input.css -o ./static/src/output.css &&
                     gunicorn roboprop.wsgi:application --bind 0.0.0.0:8000"
     volumes:
       - .:/microservice:rw # map data and files from parent directory in host to microservice directory in docker containe
@@ -29,5 +30,4 @@ services:
 
 
 volumes:
-  postgres_data:
   static_volume:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -17,7 +17,7 @@ services:
                     npx tailwindcss -i ./static/src/input.css -o ./static/src/output.css &&
                     gunicorn roboprop.wsgi:application --bind 0.0.0.0:8000"
     volumes:
-      - .:/roboprop:rw # map data and files from parent directory in host to roboprop directory in docker container
+      - .:/roboprop:rw # map files from the host to the container, useful for development
       - static_volume:/home/app/roboprop/static
     env_file:
       - .env

--- a/example.env
+++ b/example.env
@@ -1,4 +1,6 @@
 FILESERVER_URL=
 FILESERVER_API_KEY=
-# Only if you have a pro account with BlenderKit
 BLENDERKIT_PRO_API_KEY=
+
+SECRET_KEY=
+DJANGO_ALLOWED_HOSTS=localhost 127.0.0.1 [::1]

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,0 +1,4 @@
+FROM nginx:1.25.2
+
+RUN rm /etc/nginx/conf.d/default.conf
+COPY nginx.conf /etc/nginx/conf.d

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -13,7 +13,7 @@ server {
         proxy_redirect off;
     }
     location /static/ {
-        alias /home/app/microservice/static/;
+        alias /home/app/roboprop/static/;
     }
 
 }

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,0 +1,19 @@
+upstream roboprop {
+    server web:8000;
+}
+
+server {
+
+    listen 80;
+
+    location / {
+        proxy_pass http://roboprop;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header Host $host;
+        proxy_redirect off;
+    }
+    location /static/ {
+        alias /home/app/microservice/static/;
+    }
+
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ python-dotenv
 requests
 xmltodict
 boto3
+gunicorn

--- a/roboprop/settings.py
+++ b/roboprop/settings.py
@@ -27,13 +27,13 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/4.2/howto/deployment/checklist/
 
-# SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = "django-insecure-f2mrzq3^3v%b^r^vtji9gi1dp=4eac*_tub7%m40j(d=*kt8*$"
+SECRET_KEY = os.environ.get("SECRET_KEY")
 
-# SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
+DEBUG = bool(os.environ.get("DEBUG", default=0))
 
-ALLOWED_HOSTS = []
+# 'DJANGO_ALLOWED_HOSTS' should be a single string of hosts with a space between each.
+# For example: 'DJANGO_ALLOWED_HOSTS=localhost 127.0.0.1 [::1]'
+ALLOWED_HOSTS = os.environ.get("DJANGO_ALLOWED_HOSTS").split(" ")
 
 
 # Application definition
@@ -79,6 +79,7 @@ TEMPLATES = [
 
 WSGI_APPLICATION = "roboprop.wsgi.application"
 
+CSRF_TRUSTED_ORIGINS = ["http://roboprop", "http://localhost:1300"]
 
 # Database
 # https://docs.djangoproject.com/en/4.2/ref/settings/#databases

--- a/roboprop/settings.py
+++ b/roboprop/settings.py
@@ -79,7 +79,7 @@ TEMPLATES = [
 
 WSGI_APPLICATION = "roboprop.wsgi.application"
 
-CSRF_TRUSTED_ORIGINS = ["http://roboprop", "http://localhost:1300"]
+CSRF_TRUSTED_ORIGINS = ["http://roboprop", "http://localhost", "http://127.0.0.0"]
 
 # Database
 # https://docs.djangoproject.com/en/4.2/ref/settings/#databases


### PR DESCRIPTION
For a more user friendly production installation, the client has been dockerized. Usual `docker compose build` / `docker compose up` commands.

One discussion point is currently this just uses sqlite as its db. Keep it as it is (and so just letting the user rewrite for their own db of choice" or should we put add something like postgres instead to begin with?

@deku-95  is also doing some docker stuff so FYI for him