### PR TITLE
Turn off automatic model optimization

### DIFF
--- a/roboprop_client/blender_scripts/export_glb.py
+++ b/roboprop_client/blender_scripts/export_glb.py
@@ -14,15 +14,15 @@ else:
 args = parser.parse_known_args(argv)[0]
 
 # Add Palanar Decimate modifyer to all meshes
-angle_limit = 12.0  # merge faces within this angle
-for obj in bpy.data.objects:
-    if obj.type == "MESH":
-        bpy.context.view_layer.objects.active = obj
-        bpy.ops.object.modifier_add(type="DECIMATE")
-        modifier = bpy.context.object.modifiers[-1]
-        modifier.decimate_type = "DISSOLVE"
-        modifier.angle_limit = angle_limit / 180.0 * 3.14159
-        bpy.ops.object.modifier_apply(modifier=modifier.name)
+# angle_limit = 12.0  # merge faces within this angle
+# for obj in bpy.data.objects:
+#     if obj.type == "MESH":
+#         bpy.context.view_layer.objects.active = obj
+#         bpy.ops.object.modifier_add(type="DECIMATE")
+#         modifier = bpy.context.object.modifiers[-1]
+#         modifier.decimate_type = "DISSOLVE"
+#         modifier.angle_limit = angle_limit / 180.0 * 3.14159
+#         bpy.ops.object.modifier_apply(modifier=modifier.name)
 
 bpy.ops.export_scene.gltf(
     filepath=args.output,

--- a/roboprop_client/blender_scripts/export_obj.py
+++ b/roboprop_client/blender_scripts/export_obj.py
@@ -16,15 +16,15 @@ args = parser.parse_known_args(argv)[0]
 output = Path(args.output)
 
 # Add Palanar Decimate modifyer to all meshes
-angle_limit = 12.0  # merge faces within this angle
-for obj in bpy.data.objects:
-    if obj.type == "MESH":
-        bpy.context.view_layer.objects.active = obj
-        bpy.ops.object.modifier_add(type="DECIMATE")
-        modifier = bpy.context.object.modifiers[-1]
-        modifier.decimate_type = "DISSOLVE"
-        modifier.angle_limit = angle_limit / 180.0 * 3.14159
-        bpy.ops.object.modifier_apply(modifier=modifier.name)
+# angle_limit = 12.0  # merge faces within this angle
+# for obj in bpy.data.objects:
+#     if obj.type == "MESH":
+#         bpy.context.view_layer.objects.active = obj
+#         bpy.ops.object.modifier_add(type="DECIMATE")
+#         modifier = bpy.context.object.modifiers[-1]
+#         modifier.decimate_type = "DISSOLVE"
+#         modifier.angle_limit = angle_limit / 180.0 * 3.14159
+#         bpy.ops.object.modifier_apply(modifier=modifier.name)
 
 bpy.ops.file.unpack_all(method="USE_LOCAL")
 


### PR DESCRIPTION
This will probably fix the cases where half of the model is missing in the generated glTF/OBJ files.