### PR TITLE
Update export

### DIFF
--- a/convert_blend.py
+++ b/convert_blend.py
@@ -11,9 +11,11 @@ from roboprop_client.export_model import export_sdf
 
 load_dotenv()
 
+FILESERVER_URL = os.getenv("FILESERVER_URL", "")
+
 
 def _add_model_metadata(config):
-    url = os.getenv("FILESERVER_URL", "") + f"files/index.json"
+    url = FILESERVER_URL + f"files/index.json"
     response = requests.get(
         url,
         headers={"X-DreamFactory-Api-Key": os.getenv("FILESERVER_API_KEY", "")},
@@ -25,12 +27,11 @@ def _add_model_metadata(config):
         model_metadata["source"] = "upload"
         model_metadata["scale"] = 1.0
         model_metadata["url"] = (
-            os.getenv("FILESERVER_URL", "")
-            + f"files/models/{config.roboprop_key}/?zip=true"
+            FILESERVER_URL + f"files/models/{config.roboprop_key}/?zip=true"
         )
         index[model_name] = model_metadata
         response = requests.put(
-            os.getenv("FILESERVER_URL", "") + f"files/index.json",
+            url,
             data=json.dumps(index),
             headers={"X-DreamFactory-Api-Key": os.getenv("FILESERVER_API_KEY", "")},
         )
@@ -47,9 +48,8 @@ def _upload_model_to_roboprop(args, config):
     with open(f"{zip_file}.zip", "rb") as zip_file:
         files = {"files": (zip_file.name, zip_file)}
         url = (
-            os.getenv("FILESERVER_URL", "")
-            + f"files/models/{config.roboprop_key}/"
-            + "?extract=true&clean=true"
+            FILESERVER_URL
+            + f"files/models/{config.roboprop_key}/?extract=true&clean=true"
         )
         response = requests.post(
             url,

--- a/convert_blend.py
+++ b/convert_blend.py
@@ -14,6 +14,7 @@ load_dotenv()
 class Config:
     roboprop_key: str
     blend_file: Path
+    metadata: dict
     # TODO add description and other fields needed for RoboProp models
 
     @classmethod
@@ -21,12 +22,14 @@ class Config:
         with open(path) as f:
             config = yaml.safe_load(f)
             # validate config
+            assert config is not None, "roboprop.yaml is empty"
             assert "roboprop_key" in config, "roboprop_key is missing in roboprop.yaml"
             assert "blend_file" in config, "blend_file is missing in roboprop.yaml"
 
             return Config(
                 roboprop_key=config["roboprop_key"],
                 blend_file=config["blend_file"],
+                metadata=config.get("metadata", {}),
             )
 
 
@@ -40,7 +43,7 @@ def main():
     parser.add_argument(
         "--out",
         type=str,
-        default="/home/azazdeaz/repos/art-e-fact/RoboProp/models",
+        default="./models",
         help="Output path",
     )
     parser.add_argument(

--- a/convert_blend.py
+++ b/convert_blend.py
@@ -1,19 +1,43 @@
 import argparse
-import os
+from dataclasses import dataclass
+import yaml
 from pathlib import Path
 from roboprop_client.export_model import export_sdf
 
 
+@dataclass
+class Config:
+    roboprop_key: str
+    blend_file: Path
+    # TODO add description and other fields needed for RoboProp models
+
+    @classmethod
+    def from_yaml(cls, path: Path):
+        with open(path) as f:
+            config = yaml.safe_load(f)
+            # validate config
+            assert "roboprop_key" in config, "roboprop_key is missing in roboprop.yaml"
+            assert "blend_file" in config, "blend_file is missing in roboprop.yaml"
+
+            return Config(
+                roboprop_key=config["roboprop_key"],
+                blend_file=config["blend_file"],
+            )
+
+
 def main():
-    parser = argparse.ArgumentParser(description="Convert .blend file to model format")
-    parser.add_argument("blend_file", type=str, help="Path to the .blend file")
-    parser.add_argument(
-        "--name",
-        type=str,
-        default=None,
-        help="Name of the model. Defaults to the name of the .blend file",
+    parser = argparse.ArgumentParser(
+        description="Convert .blend file to model format using the roboprop.yaml config"
     )
-    parser.add_argument("--out", type=str, default=None, help="Output path")
+    parser.add_argument(
+        "roboprop_file", type=str, help="Path to the roboprop.yaml file"
+    )
+    parser.add_argument(
+        "--out",
+        type=str,
+        default="/home/azazdeaz/repos/art-e-fact/RoboProp/models",
+        help="Output path",
+    )
     parser.add_argument(
         "--upload",
         action="store_true",
@@ -22,15 +46,19 @@ def main():
     )
 
     args = parser.parse_args()
+    roboprop_file = Path(args.roboprop_file)
 
-    if args.name is None:
-        args.name = os.path.splitext(os.path.basename(args.blend_file))[0]
+    # read roboprop.yaml
+    config = Config.from_yaml(roboprop_file)
+    print(f"Config:\n{config}")
 
     export_sdf(
-        out_dir=Path(args.out),
-        model_name=args.name,
-        blend_file_path=Path(args.blend_file),
+        out_dir=Path(args.out) / config.roboprop_key,
+        model_name=config.roboprop_key,
+        blend_file_path=roboprop_file.parent / config.blend_file,
     )
+
+    # TODO: upload to RoboProp
 
 
 if __name__ == "__main__":

--- a/convert_blend.py
+++ b/convert_blend.py
@@ -1,0 +1,37 @@
+import argparse
+import os
+from pathlib import Path
+from roboprop_client.export_model import export_sdf
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Convert .blend file to model format")
+    parser.add_argument("blend_file", type=str, help="Path to the .blend file")
+    parser.add_argument(
+        "--name",
+        type=str,
+        default=None,
+        help="Name of the model. Defaults to the name of the .blend file",
+    )
+    parser.add_argument("--out", type=str, default=None, help="Output path")
+    parser.add_argument(
+        "--upload",
+        action="store_true",
+        default=False,
+        help="Upload the result to RoboProp",
+    )
+
+    args = parser.parse_args()
+
+    if args.name is None:
+        args.name = os.path.splitext(os.path.basename(args.blend_file))[0]
+
+    export_sdf(
+        out_dir=Path(args.out),
+        model_name=args.name,
+        blend_file_path=Path(args.blend_file),
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/convert_blend.py
+++ b/convert_blend.py
@@ -64,14 +64,12 @@ def main():
     )
 
     if args.upload:
-        # Define the directory to be zipped and the output zip file name
         model_folder = Path(args.out) / config.roboprop_key
         zip_file = config.roboprop_key
         shutil.make_archive(zip_file, 'zip', model_folder)
         with open(f"{zip_file}.zip", "rb") as zip_file:
             files = {"files": (zip_file.name, zip_file)}
             url = os.getenv("FILESERVER_URL", "") + f"models/{config.roboprop_key}/" + "?extract=true&clean=true"
-            # At present all files are uploaded as a zip file.
             response = requests.post(
                 url,
                 files=files,

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ xmltodict
 boto3
 gunicorn
 bpy
+pyYAML

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,5 @@ requests
 xmltodict
 boto3
 gunicorn
-bpy
 pyYAML
+bpy==4.0.0

--- a/roboprop_client/blender_scripts/export_fbx.py
+++ b/roboprop_client/blender_scripts/export_fbx.py
@@ -1,6 +1,7 @@
 import bpy
 from pathlib import Path
 
+
 def export_fbx(blend_file: Path, output: Path):
     # Reset the state of Blender
     bpy.ops.wm.read_factory_settings(use_empty=True)
@@ -15,6 +16,6 @@ def export_fbx(blend_file: Path, output: Path):
         check_existing=False,
         object_types={"MESH"},
         path_mode="COPY",
-        embed_textures=False, # Gazebo can't handle embedded textures
+        embed_textures=False,  # Gazebo can't handle embedded textures
         apply_scale_options="FBX_SCALE_ALL",
     )

--- a/roboprop_client/blender_scripts/export_fbx.py
+++ b/roboprop_client/blender_scripts/export_fbx.py
@@ -1,0 +1,20 @@
+import bpy
+from pathlib import Path
+
+def export_fbx(blend_file: Path, output: Path):
+    # Reset the state of Blender
+    bpy.ops.wm.read_factory_settings(use_empty=True)
+    # Load the blend file
+    bpy.ops.wm.open_mainfile(filepath=str(blend_file))
+    # Move texture images to external files so the exporter can copy them next to the model
+    bpy.ops.file.unpack_all(method="USE_LOCAL")
+    # Export FBX
+    # https://docs.blender.org/api/current/bpy.ops.export_scene.html#module-bpy.ops.export_scene
+    bpy.ops.export_scene.fbx(
+        filepath=str(output),
+        check_existing=False,
+        object_types={"MESH"},
+        path_mode="COPY",
+        embed_textures=False, # Gazebo can't handle embedded textures
+        apply_scale_options="FBX_SCALE_ALL",
+    )

--- a/roboprop_client/blender_scripts/export_glb.py
+++ b/roboprop_client/blender_scripts/export_glb.py
@@ -1,6 +1,7 @@
 import bpy
 from pathlib import Path
 
+
 def _export(blend_file: Path, output: Path, format: str):
     # Reset the state of Blender
     bpy.ops.wm.read_factory_settings(use_empty=True)
@@ -25,8 +26,10 @@ def _export(blend_file: Path, output: Path, format: str):
         export_def_bones=True,
     )
 
+
 def export_glb(blend_file: Path, output: Path):
     _export(blend_file, output, "GLB")
+
 
 def export_gltf(blend_file: Path, output: Path):
     _export(blend_file, output, "GLTF_SEPARATE")

--- a/roboprop_client/blender_scripts/export_glb.py
+++ b/roboprop_client/blender_scripts/export_glb.py
@@ -19,6 +19,10 @@ def _export(blend_file: Path, output: Path, format: str):
         export_image_format="JPEG",
         export_jpeg_quality=60,
         export_extras=True,
+        # the export rigged models in pos, export_def_bones=True and export_rest_position_armature=False are needed
+        export_rest_position_armature=False,
+        # export_hierarchy_flatten_bones=True,
+        export_def_bones=True,
     )
 
 def export_glb(blend_file: Path, output: Path):

--- a/roboprop_client/blender_scripts/export_glb.py
+++ b/roboprop_client/blender_scripts/export_glb.py
@@ -18,6 +18,7 @@ def _export(blend_file: Path, output: Path, format: str):
         export_format=format,
         export_image_format="JPEG",
         export_jpeg_quality=60,
+        export_extras=True,
     )
 
 def export_glb(blend_file: Path, output: Path):

--- a/roboprop_client/blender_scripts/export_glb.py
+++ b/roboprop_client/blender_scripts/export_glb.py
@@ -1,35 +1,27 @@
 import bpy
 from pathlib import Path
-import argparse
-import sys
 
-parser = argparse.ArgumentParser()
-parser.add_argument("-o", "--output", dest="output", required=True)
+def _export(blend_file: Path, output: Path, format: str):
+    # Reset the state of Blender
+    bpy.ops.wm.read_factory_settings(use_empty=True)
+    # Load the blend file
+    bpy.ops.wm.open_mainfile(filepath=str(blend_file))
+    if format == "GLTF_SEPARATE":
+        # Move texture images to external files so the exporter can copy them next to the model
+        bpy.ops.file.unpack_all(method="USE_LOCAL")
+    # Export GLB
+    bpy.ops.export_scene.gltf(
+        filepath=str(output),
+        check_existing=False,
+        use_selection=False,
+        export_materials="EXPORT",
+        export_format=format,
+        export_image_format="JPEG",
+        export_jpeg_quality=60,
+    )
 
+def export_glb(blend_file: Path, output: Path):
+    _export(blend_file, output, "GLB")
 
-if "--" in sys.argv:
-    argv = sys.argv[sys.argv.index("--") + 1 :]
-else:
-    argv = []
-args = parser.parse_known_args(argv)[0]
-
-# Add Palanar Decimate modifyer to all meshes
-# angle_limit = 12.0  # merge faces within this angle
-# for obj in bpy.data.objects:
-#     if obj.type == "MESH":
-#         bpy.context.view_layer.objects.active = obj
-#         bpy.ops.object.modifier_add(type="DECIMATE")
-#         modifier = bpy.context.object.modifiers[-1]
-#         modifier.decimate_type = "DISSOLVE"
-#         modifier.angle_limit = angle_limit / 180.0 * 3.14159
-#         bpy.ops.object.modifier_apply(modifier=modifier.name)
-
-bpy.ops.export_scene.gltf(
-    filepath=args.output,
-    check_existing=False,
-    use_selection=False,
-    export_materials="EXPORT",
-    export_format="GLB",
-    export_image_format="JPEG",
-    export_jpeg_quality=60,
-)
+def export_gltf(blend_file: Path, output: Path):
+    _export(blend_file, output, "GLTF_SEPARATE")

--- a/roboprop_client/blender_scripts/export_obj.py
+++ b/roboprop_client/blender_scripts/export_obj.py
@@ -1,6 +1,7 @@
 import bpy
 from pathlib import Path
 
+
 def export_obj(blend_file: Path, output: Path):
     # Reset the state of Blender
     bpy.ops.wm.read_factory_settings(use_empty=True)

--- a/roboprop_client/blender_scripts/export_obj.py
+++ b/roboprop_client/blender_scripts/export_obj.py
@@ -1,42 +1,26 @@
 import bpy
 from pathlib import Path
-import argparse
-import sys
-import os
 
-parser = argparse.ArgumentParser()
-parser.add_argument("-o", "--output", dest="output", required=True)
-
-
-if "--" in sys.argv:
-    argv = sys.argv[sys.argv.index("--") + 1 :]
-else:
-    argv = []
-args = parser.parse_known_args(argv)[0]
-output = Path(args.output)
-
-# Add Palanar Decimate modifyer to all meshes
-# angle_limit = 12.0  # merge faces within this angle
-# for obj in bpy.data.objects:
-#     if obj.type == "MESH":
-#         bpy.context.view_layer.objects.active = obj
-#         bpy.ops.object.modifier_add(type="DECIMATE")
-#         modifier = bpy.context.object.modifiers[-1]
-#         modifier.decimate_type = "DISSOLVE"
-#         modifier.angle_limit = angle_limit / 180.0 * 3.14159
-#         bpy.ops.object.modifier_apply(modifier=modifier.name)
-
-bpy.ops.file.unpack_all(method="USE_LOCAL")
-
-bpy.ops.export_scene.obj(
-    filepath=args.output,
-    check_existing=False,
-    # Use ROS coordinate frame
-    axis_forward="Y",
-    axis_up="Z",
-    use_selection=False,
-    use_materials=True,
-    use_triangles=True,
-    # copy all the texture images next to the model
-    path_mode="COPY",
-)
+def export_obj(blend_file: Path, output: Path):
+    # Reset the state of Blender
+    bpy.ops.wm.read_factory_settings(use_empty=True)
+    # Load the blend file
+    bpy.ops.wm.open_mainfile(filepath=str(blend_file))
+    # Move texture images to external files so the exporter can copy them next to the model
+    bpy.ops.file.unpack_all(method="USE_LOCAL")
+    # Export OBJ
+    bpy.ops.wm.obj_export(
+        filepath=str(output),
+        check_existing=False,
+        export_selected_objects=False,
+        export_uv=True,
+        export_normals=True,
+        export_colors=True,
+        export_materials=True,
+        export_pbr_extensions=True,
+        # copy all the texture images next to the model
+        path_mode="COPY",
+        export_triangulated_mesh=True,
+        export_object_groups=True,
+        export_material_groups=True,
+    )

--- a/roboprop_client/blender_scripts/gltf_to_obj.py
+++ b/roboprop_client/blender_scripts/gltf_to_obj.py
@@ -1,0 +1,26 @@
+import bpy
+bpy.ops.wm.read_factory_settings(use_empty=True)
+bpy.ops.import_scene.gltf(
+    filepath="/home/azazdeaz/repos/art-e-fact/urdfs/roboprop/BumerangChair/assets/visual.glb",
+    files=[{"name": "visual.glb", "name": "visual.glb"}],
+    loglevel=50,
+)
+bpy.ops.file.unpack_all(method='WRITE_LOCAL')
+bpy.ops.wm.obj_export(
+    filepath="/home/azazdeaz/repos/art-e-fact/urdfs/roboprop/BumerangChair/assets/gen/visual.obj",
+    check_existing=False,
+    # # Use ROS coordinate frame
+    # axis_forward="X",
+    # axis_up="Z",
+    export_selected_objects=False,
+    export_uv=True,
+    export_normals=True,
+    export_colors=True,
+    export_materials=True,
+    export_pbr_extensions=True,
+    # copy all the texture images next to the model
+    path_mode="COPY",
+    export_triangulated_mesh=True,
+    export_object_groups=True,
+    export_material_groups=True,
+)

--- a/roboprop_client/blender_scripts/gltf_to_obj.py
+++ b/roboprop_client/blender_scripts/gltf_to_obj.py
@@ -1,11 +1,12 @@
 import bpy
+
 bpy.ops.wm.read_factory_settings(use_empty=True)
 bpy.ops.import_scene.gltf(
     filepath="/home/azazdeaz/repos/art-e-fact/urdfs/roboprop/BumerangChair/assets/visual.glb",
     files=[{"name": "visual.glb", "name": "visual.glb"}],
     loglevel=50,
 )
-bpy.ops.file.unpack_all(method='WRITE_LOCAL')
+bpy.ops.file.unpack_all(method="WRITE_LOCAL")
 bpy.ops.wm.obj_export(
     filepath="/home/azazdeaz/repos/art-e-fact/urdfs/roboprop/BumerangChair/assets/gen/visual.obj",
     check_existing=False,

--- a/roboprop_client/export_model.py
+++ b/roboprop_client/export_model.py
@@ -8,7 +8,7 @@ from roboprop_client.blender_scripts.export_obj import export_obj
 
 EXPORT_CONFIGS = [
     {
-        "visual": "assets/visual.fbx",
+        "visual": "assets/visual.obj",
         "sdf": "model.sdf",
         "config": "model.config",
     },

--- a/roboprop_client/export_model.py
+++ b/roboprop_client/export_model.py
@@ -47,6 +47,11 @@ def export_sdf(path_model: Path, model_name: str, blend_file_path: str):
                 model, "link", attrib={"name": f"{model_name}_link"}
             )
 
+            link.append(ElementTree.Comment("Convert model orientations from right-handed y-up z-back to ROS"))
+            pose = ElementTree.SubElement(link, "pose")
+            pose.set("degrees", "1")
+            pose.text = "0 0 0 90 0 -90"
+
             visual = ElementTree.SubElement(
                 link, "visual", attrib={"name": f"{model_name}_visual"}
             )

--- a/roboprop_client/export_model.py
+++ b/roboprop_client/export_model.py
@@ -2,127 +2,106 @@ import os
 from xml.dom import minidom
 from xml.etree import ElementTree
 from pathlib import Path
-import subprocess
+from roboprop_client.blender_scripts.export_glb import export_glb, export_gltf
+from roboprop_client.blender_scripts.export_fbx import export_fbx
+from roboprop_client.blender_scripts.export_obj import export_obj
 
-# COLLISION_EXTENSION = ".stl"
-OBJECT_TYPES = [["default", ".obj"], ["gltf", ".glb"]]
+EXPORT_CONFIGS = [
+    {
+        "visual": "assets/visual.fbx",
+        "sdf": "model.sdf",
+        "config": "model.config",
+    },
+    {
+        "visual": "assets/visual.glb",
+        "sdf": "glft-model.sdf",
+        "config": "glft-model.config",
+    },
+]
 
 
-def export_sdf(path_model: Path, model_name: str, blend_file_path: str):
-    # path_collision = os.path.join(path_model, f"assets/collision{COLLISION_EXTENSION}")
-    visual_paths = [
-        os.path.join(path_model, f"assets/visual{ext}") for _, ext in OBJECT_TYPES
-    ]
-    sdf_paths = [
-        os.path.join(
-            path_model, "model.sdf" if sim == "default" else f"{sim}-model.sdf"
-        )
-        for sim, _ in OBJECT_TYPES
-    ]
-    config_paths = [
-        os.path.join(
-            path_model, "model.config" if sim == "default" else f"{sim}-model.config"
-        )
-        for sim, _ in OBJECT_TYPES
-    ]
+# Util for saving an XML file
+def write_xml(xml: ElementTree.Element, filepath: Path):
+    xml_string = minidom.parseString(
+        ElementTree.tostring(xml, encoding="unicode")
+    ).toprettyxml(indent="  ")
+    file = open(filepath, "w")
+    file.write(xml_string)
+    file.close()
+    print(f"Saved: {filepath}")
+
+
+def export_sdf(out_dir: Path, model_name: str, blend_file_path: Path):
     sdf_version = "1.9"
 
-    # Util for saving an XML file
-    def write_xml(xml: ElementTree.Element, filepath: str):
-        xml_string = minidom.parseString(
-            ElementTree.tostring(xml, encoding="unicode")
-        ).toprettyxml(indent="  ")
-        file = open(filepath, "w")
-        file.write(xml_string)
-        file.close()
-        print(f"Saved: {filepath}")
+    for export_config in EXPORT_CONFIGS:
+        visual_path = out_dir / export_config["visual"]
+        sdf_path = out_dir / export_config["sdf"]
+        config_path = out_dir / export_config["config"]
 
-    def generate_sdf():
-        for path_sdf, path_visual in zip(sdf_paths, visual_paths):
-            sdf = ElementTree.Element("sdf", attrib={"version": sdf_version})
-            model = ElementTree.SubElement(sdf, "model", attrib={"name": model_name})
-            static_xml = ElementTree.SubElement(model, "static")
-            static_xml.text = str(False)
-            link = ElementTree.SubElement(
-                model, "link", attrib={"name": f"{model_name}_link"}
+        # Export visual model
+        os.makedirs(name=os.path.dirname(visual_path), exist_ok=True)
+        if Path(visual_path).suffix == ".fbx":
+            export_fbx(blend_file_path, visual_path)
+        elif Path(visual_path).suffix == ".glb":
+            export_glb(blend_file_path, visual_path)
+        elif Path(visual_path).suffix == ".gltf":
+            export_gltf(blend_file_path, visual_path)
+        elif Path(visual_path).suffix == ".obj":
+            export_obj(blend_file_path, visual_path)
+        else:
+            raise ValueError(
+                f"Exporting models the with extension '{Path(visual_path).suffix}' is not implemented yet. (Appears in {visual_path})"
             )
 
-            link.append(ElementTree.Comment("Convert model orientations from right-handed y-up z-back to ROS"))
-            pose = ElementTree.SubElement(link, "pose")
-            pose.set("degrees", "1")
-            pose.text = "0 0 0 90 0 -90"
+        print(f"Saved {visual_path}")
 
-            visual = ElementTree.SubElement(
-                link, "visual", attrib={"name": f"{model_name}_visual"}
+        # Generate SDF
+        sdf = ElementTree.Element("sdf", attrib={"version": sdf_version})
+        model = ElementTree.SubElement(sdf, "model", attrib={"name": model_name})
+        static_xml = ElementTree.SubElement(model, "static")
+        static_xml.text = str(False)
+        link = ElementTree.SubElement(
+            model, "link", attrib={"name": f"{model_name}_link"}
+        )
+
+        link.append(
+            ElementTree.Comment(
+                "Convert model orientations from right-handed y-up z-back to ROS"
             )
-            visual_geometry = ElementTree.SubElement(visual, "geometry")
-            visual_mesh = ElementTree.SubElement(visual_geometry, "mesh")
-            visual_mesh_uri = ElementTree.SubElement(visual_mesh, "uri")
-            visual_mesh_uri.text = os.path.relpath(
-                path_visual, os.path.dirname(path_sdf)
-            )
-            collision = ElementTree.SubElement(
-                link, "collision", attrib={"name": f"{model_name}_collision"}
-            )
-            collision_geometry = ElementTree.SubElement(collision, "geometry")
-            collision_mesh = ElementTree.SubElement(collision_geometry, "mesh")
-            collision_mesh_uri = ElementTree.SubElement(collision_mesh, "uri")
-            collision_mesh_uri.text = os.path.relpath(
-                path_visual, os.path.dirname(path_sdf)
-            )
+        )
+        pose = ElementTree.SubElement(link, "pose")
+        pose.set("degrees", "1")
+        pose.text = "0 0 0 90 0 -90"
 
-            write_xml(sdf, path_sdf)
+        visual = ElementTree.SubElement(
+            link, "visual", attrib={"name": f"{model_name}_visual"}
+        )
+        visual_geometry = ElementTree.SubElement(visual, "geometry")
+        visual_mesh = ElementTree.SubElement(visual_geometry, "mesh")
+        visual_mesh_uri = ElementTree.SubElement(visual_mesh, "uri")
+        visual_mesh_uri.text = os.path.relpath(visual_path, os.path.dirname(sdf_path))
+        collision = ElementTree.SubElement(
+            link, "collision", attrib={"name": f"{model_name}_collision"}
+        )
+        collision_geometry = ElementTree.SubElement(collision, "geometry")
+        collision_mesh = ElementTree.SubElement(collision_geometry, "mesh")
+        collision_mesh_uri = ElementTree.SubElement(collision_mesh, "uri")
+        collision_mesh_uri.text = os.path.relpath(
+            visual_path, os.path.dirname(sdf_path)
+        )
 
-    # Generate a minimal config file. For more options, see: https://github.com/gazebosim/gz-sim/blob/a738dec47ae4f5c18f48a6d4d4b0edb500a490fa/examples/scripts/blender/procedural_dataset_generator.py#L1161-L1211
-    def generate_config():
-        for path_sdf, path_config in zip(sdf_paths, config_paths):
-            model_config = ElementTree.Element("model")
-            name = ElementTree.SubElement(model_config, "name")
-            name.text = model_name
+        write_xml(sdf, sdf_path)
 
-            # Path to SDF
-            sdf_tag = ElementTree.SubElement(
-                model_config, "sdf", attrib={"version": sdf_version}
-            )
-            sdf_tag.text = os.path.relpath(path_sdf, os.path.dirname(path_config))
+        # Generate a minimal config file. For more options, see: https://github.com/gazebosim/gz-sim/blob/a738dec47ae4f5c18f48a6d4d4b0edb500a490fa/examples/scripts/blender/procedural_dataset_generator.py#L1161-L1211
+        model_config = ElementTree.Element("model")
+        name = ElementTree.SubElement(model_config, "name")
+        name.text = model_name
 
-            write_xml(model_config, path_config)
+        # Path to SDF
+        sdf_tag = ElementTree.SubElement(
+            model_config, "sdf", attrib={"version": sdf_version}
+        )
+        sdf_tag.text = os.path.relpath(sdf_path, os.path.dirname(config_path))
 
-    def export_model(with_materials: bool):
-        def run_export(export_script):
-            cmd = [
-                "blender",
-                blend_file_path,
-                "--background",
-                "--factory-startup",
-                "--python",
-                Path(__file__).parent / "blender_scripts" / export_script,
-                "--",
-                "--output",
-                path_visual,
-            ]
-            result = subprocess.run(cmd, capture_output=True, text=True)
-            if result.stdout:
-                print(result.stdout)
-            if result.stderr:
-                print(result.stderr)
-
-        for path_visual in visual_paths:
-            os.makedirs(name=os.path.dirname(path_visual), exist_ok=True)
-            if Path(path_visual).suffix == ".obj":
-                run_export("export_obj.py")
-            elif Path(path_visual).suffix == ".glb":
-                run_export("export_glb.py")
-            else:
-                raise ValueError(
-                    f"Exporting models the with extension '{Path(path_visual).suffix}' is not implemented yet. (Appears in {path_visual})"
-                )
-
-        print(f"Saved {path_visual}")
-
-    export_model(with_materials=True)
-
-    # Create the model.sdf file
-    generate_sdf()
-    # Create the model.config file
-    generate_config()
+        write_xml(model_config, config_path)

--- a/roboprop_client/load_blenderkit.py
+++ b/roboprop_client/load_blenderkit.py
@@ -95,12 +95,14 @@ def add_demo_world(model_path: Path):
     return demo_path
 
 
-def load_blenderkit_model(asset_base_id: str, output_path: str, model_name: str | None = None):
+def load_blenderkit_model(
+    asset_base_id: str, output_path: str, model_name: str | None = None
+):
     # Load asset meta data from BlenderKit
     meta = load_asset_meta(asset_base_id)
 
     if not model_name:
-        model_name = meta["name"] 
+        model_name = meta["name"]
 
     blend_file = load_model_from_blenderkit(meta)
     model_path = Path(output_path) / model_name

--- a/roboprop_client/load_blenderkit.py
+++ b/roboprop_client/load_blenderkit.py
@@ -1,19 +1,10 @@
 import uuid
 from pathlib import Path
 import requests
-import sys
-import os
 import argparse
-import sys
 import json
 import roboprop_client.utils as utils
-
-# Trick to allow importing from the same directory in Blender
-script_dir = os.path.dirname(os.path.realpath(__file__))
-if script_dir not in sys.path:
-    sys.path.append(script_dir)
-
-from export_model import export_sdf
+from roboprop_client.export_model import export_sdf
 
 CACHE_PATH = Path(".cache")
 
@@ -38,11 +29,13 @@ def load_asset_meta(asset_base_id: str):
     response = requests.get(url_path)
     data = response.json()
     if data["count"] == 0 or data["count"] > 1:
-        return
+        raise ValueError(
+            "Error: BlenderKit API returned no or multiple results for this asset_base_id"
+        )
     return data["results"][0]
 
 
-def load_model_from_blenderkit(meta):
+def load_model_from_blenderkit(meta) -> Path:
     asset_id = meta["id"]
 
     # Create output directory
@@ -62,7 +55,7 @@ def load_model_from_blenderkit(meta):
             download_url = file["downloadUrl"]
 
     if download_url is None:
-        return
+        raise ValueError("Error: No blend file found for this model meta")
 
     # Create a random scene uuid which is necessary for downloading files
     scene_uuid = str(uuid.uuid4())
@@ -102,12 +95,12 @@ def add_demo_world(model_path: Path):
     return demo_path
 
 
-def load_blenderkit_model(asset_base_id: str, output_path: str, model_name: str = None):
+def load_blenderkit_model(asset_base_id: str, output_path: str, model_name: str | None = None):
     # Load asset meta data from BlenderKit
     meta = load_asset_meta(asset_base_id)
 
     if not model_name:
-        model_name = meta["name"]
+        model_name = meta["name"] 
 
     blend_file = load_model_from_blenderkit(meta)
     model_path = Path(output_path) / model_name


### PR DESCRIPTION
 - Add .fbx and .glft export options (supported by Gazebo Harmonic)
 - Use the official `bpy` python package
    - This packages includes a blender binary so we don't need to install Blender anymore for RoboProp
 - Refactor export script 