### PR TITLE
allow use of collectstatic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,4 @@ static/src/output.css
 
 models/
 textures/
+staticfiles/

--- a/roboprop/settings.py
+++ b/roboprop/settings.py
@@ -79,7 +79,11 @@ TEMPLATES = [
 
 WSGI_APPLICATION = "roboprop.wsgi.application"
 
-CSRF_TRUSTED_ORIGINS = ["https://roboprop-dev.artefacts.com", "http://localhost", "http://127.0.0.0"]
+CSRF_TRUSTED_ORIGINS = [
+    "https://roboprop-dev.artefacts.com",
+    "http://localhost",
+    "http://127.0.0.0",
+]
 
 # Database
 # https://docs.djangoproject.com/en/4.2/ref/settings/#databases
@@ -127,6 +131,7 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/4.2/howto/static-files/
 
 STATIC_URL = "static/"
+STATIC_ROOT = BASE_DIR / "staticfiles"
 
 # Default primary key field type
 # https://docs.djangoproject.com/en/4.2/ref/settings/#default-auto-field
@@ -135,9 +140,17 @@ DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
 COMPRESS_ROOT = BASE_DIR / "static"
 
+STATICFILES_DIRS = [
+    "static",
+]
+
 COMPRESS_ENABLED = True
 
-STATICFILES_FINDERS = ("compressor.finders.CompressorFinder",)
+STATICFILES_FINDERS = (
+    "compressor.finders.CompressorFinder",
+    "django.contrib.staticfiles.finders.FileSystemFinder",
+    "django.contrib.staticfiles.finders.AppDirectoriesFinder",
+)
 
 LOGIN_URL = "/login"
 

--- a/roboprop/urls.py
+++ b/roboprop/urls.py
@@ -14,6 +14,7 @@ Including another URLconf
     1. Import the include() function: from django.urls import include, path
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
+
 from django.contrib import admin
 from django.urls import path, include
 


### PR DESCRIPTION
Allows the use of djangos `collectstatic` helper so static files can be collected into a seperate folder (for something like nginx to serve)

At present, I dont believe technically necessary, as all Roboprop's static files are already stored outside of the application directory (in static). But useful for multiple applications within a project / security (not allowing something like nginx/apache to get inside of the django application itself)