### PR TITLE
Settings for Celery with Redis 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,4 @@ static/src/output.css
 
 models/
 textures/
+staticfiles/

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,8 @@ boto3
 gunicorn
 pyYAML
 bpy==4.0.0
+django-celery-beat 
+django-celery-results # currently requires Django 4.0 or older
+python-decouple
+redis
+celery

--- a/roboprop/__init__.py
+++ b/roboprop/__init__.py
@@ -1,0 +1,3 @@
+from .celery import app as celery_app  # noqa
+
+__all__ = ("celery_app",)

--- a/roboprop/celery.py
+++ b/roboprop/celery.py
@@ -1,0 +1,29 @@
+import os
+from celery import Celery
+from decouple import config
+
+# set the default Django settings module for the 'celery' program.
+# this is also used in manage.py
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "roboprop.settings")
+
+app = Celery("roboprop")
+
+# Using a string here means the worker don't have to serialize
+# the configuration object to child processes.
+# - namespace='CELERY' means all celery-related configuration keys
+#   should have a `CELERY_` prefix.
+app.config_from_object("django.conf:settings", namespace="CELERY")
+
+# Load task modules from all registered Django app configs.
+app.autodiscover_tasks()
+
+# We used CELERY_BROKER_URL in settings.py instead of:
+# app.conf.broker_url = ''
+
+# We used CELERY_BEAT_SCHEDULER in settings.py instead of:
+# app.conf.beat_scheduler = ''django_celery_beat.schedulers.DatabaseScheduler'
+
+
+@app.task(bind=True, ignore_result=True)
+def debug_task(self):
+    print(f"Request: {self.request!r}")

--- a/roboprop/settings.py
+++ b/roboprop/settings.py
@@ -47,6 +47,8 @@ INSTALLED_APPS = [
     "django.contrib.staticfiles",
     "roboprop_client",
     "compressor",
+    "django_celery_beat",
+    "django_celery_results",
 ]
 
 MIDDLEWARE = [
@@ -159,3 +161,7 @@ SESSION_ENGINE = "django.contrib.sessions.backends.signed_cookies"
 
 DATA_UPLOAD_MAX_MEMORY_SIZE = 104857600  # 100MB
 FILE_UPLOAD_MAX_MEMORY_SIZE = 104857600  # 100MB
+
+CELERY_RESULT_BACKEND = "django-db"
+CELERY_BROKER_URL = os.environ.get("CELERY_BROKER_REDIS_URL", "redis://localhost:6379")
+CELERY_BEAT_SCHEDULER = "django_celery_beat.schedulers.DatabaseScheduler"

--- a/roboprop_client/load_blenderkit.py
+++ b/roboprop_client/load_blenderkit.py
@@ -109,8 +109,7 @@ def load_blenderkit_model(
     # objs = bproc.loader.load_blend(blend_file)
     # bpy.ops.wm.open_mainfile(filepath=blend_file)
     # bpy.ops.file.unpack_all(method="USE_LOCAL")
-    export_sdf(model_path, model_name, blend_file)
-
+    export_sdf(out_dir=model_path, model_name=model_name, blend_file_path=blend_file)
     # Save meta data in the model folder
     meta_path = model_path / "blenderkit_meta.json"
     with open(meta_path, "w") as f:


### PR DESCRIPTION
There is a current issue affecting the blenderkit conversion process. As it now uses bpy (instead of a subprocess), conversions now occur on the main thread, fine in the CLI tool, but causing issues when using the UI through the application itself. 

Confirm a threading issue (and that bpy is not thread safe) as using `--nothreading` in the development server allows it to work fine.

This PR sets up Celery (together with Redis as its broker) so that the conversion process (and indeed any other long running task in future), can be pushed off the main thread to a background worker (next).