### PR TITLE
Move blenderkit conversion to celery

### DIFF
--- a/roboprop/settings.py
+++ b/roboprop/settings.py
@@ -162,6 +162,6 @@ SESSION_ENGINE = "django.contrib.sessions.backends.signed_cookies"
 DATA_UPLOAD_MAX_MEMORY_SIZE = 104857600  # 100MB
 FILE_UPLOAD_MAX_MEMORY_SIZE = 104857600  # 100MB
 
-CELERY_RESULT_BACKEND = "django-db"
+CELERY_RESULT_BACKEND = os.environ.get("CELERY_BROKER_REDIS_URL", "redis://localhost:6379")
 CELERY_BROKER_URL = os.environ.get("CELERY_BROKER_REDIS_URL", "redis://localhost:6379")
 CELERY_BEAT_SCHEDULER = "django_celery_beat.schedulers.DatabaseScheduler"

--- a/roboprop_client/tasks.py
+++ b/roboprop_client/tasks.py
@@ -1,0 +1,24 @@
+from celery import shared_task
+from roboprop_client.utils import (
+    _add_blenderkit_model_to_my_models,
+    _add_blenderkit_model_metadata,
+)
+
+
+@shared_task
+def add_blenderkit_model_to_my_models_task(
+    request, folder_name, asset_base_id, thumbnail, index
+):
+    try:
+        response = _add_blenderkit_model_to_my_models(
+            folder_name, asset_base_id, thumbnail
+        )
+        if response.status_code == 201:
+            metadata_response = _add_blenderkit_model_metadata(
+                request, folder_name, asset_base_id, index
+            )
+            return metadata_response
+        return response.status_code
+    except Exception as e:
+        # Handle exceptions as needed
+        return str(e)

--- a/roboprop_client/tasks.py
+++ b/roboprop_client/tasks.py
@@ -1,7 +1,7 @@
 from celery import shared_task
 from roboprop_client.utils import (
-    _add_blenderkit_model_to_my_models,
-    _add_blenderkit_model_metadata,
+    add_blenderkit_model_to_my_models,
+    add_blenderkit_model_metadata,
 )
 
 
@@ -10,11 +10,11 @@ def add_blenderkit_model_to_my_models_task(
     folder_name, asset_base_id, thumbnail, index
 ):
     try:
-        response = _add_blenderkit_model_to_my_models(
+        response = add_blenderkit_model_to_my_models(
             folder_name, asset_base_id, thumbnail
         )
         if response.status_code == 201:
-            metadata_response = _add_blenderkit_model_metadata(
+            metadata_response = add_blenderkit_model_metadata(
                 folder_name, asset_base_id, index
             )
             return metadata_response.json()

--- a/roboprop_client/tasks.py
+++ b/roboprop_client/tasks.py
@@ -7,7 +7,7 @@ from roboprop_client.utils import (
 
 @shared_task
 def add_blenderkit_model_to_my_models_task(
-    request, folder_name, asset_base_id, thumbnail, index
+    folder_name, asset_base_id, thumbnail, index
 ):
     try:
         response = _add_blenderkit_model_to_my_models(
@@ -15,9 +15,9 @@ def add_blenderkit_model_to_my_models_task(
         )
         if response.status_code == 201:
             metadata_response = _add_blenderkit_model_metadata(
-                request, folder_name, asset_base_id, index
+                folder_name, asset_base_id, index
             )
-            return metadata_response
+            return metadata_response.json()
         return response.status_code
     except Exception as e:
         # Handle exceptions as needed

--- a/roboprop_client/utils.py
+++ b/roboprop_client/utils.py
@@ -137,7 +137,7 @@ def delete_folders(folders):
             shutil.rmtree(folder)
 
 
-def _add_blenderkit_thumbnail(thumbnail, folder_name):
+def add_blenderkit_thumbnail(thumbnail, folder_name):
     thumbnail_response = requests.get(thumbnail)
     os.makedirs(os.path.join("models", folder_name, "thumbnails"), exist_ok=True)
     thumbnail_filename = os.path.basename(thumbnail)
@@ -150,10 +150,10 @@ def _add_blenderkit_thumbnail(thumbnail, folder_name):
         thumbnail_file.write(thumbnail_response.content)
 
 
-def _add_blenderkit_model_to_my_models(folder_name, asset_base_id, thumbnail):
+def add_blenderkit_model_to_my_models(folder_name, asset_base_id, thumbnail):
     load_blenderkit_model(asset_base_id, "models", folder_name)
 
-    _add_blenderkit_thumbnail(thumbnail, folder_name)
+    add_blenderkit_thumbnail(thumbnail, folder_name)
     zip_filename, zip_path = create_zip_file(folder_name)
     # Upload the ZIP file in a POST request
     with open(zip_path, "rb") as zip_file:
@@ -166,7 +166,7 @@ def _add_blenderkit_model_to_my_models(folder_name, asset_base_id, thumbnail):
     return response
 
 
-def _get_blenderkit_metadata(folder_name):
+def get_blenderkit_metadata(folder_name):
     tags = []
     categories = []
     description = []
@@ -182,7 +182,7 @@ def _get_blenderkit_metadata(folder_name):
     return tags, categories, description
 
 
-def _update_index(model_name, model_metadata, model_source, index):
+def update_index(model_name, model_metadata, model_source, index):
     url_safe_name = urllib.parse.quote(model_name)
     model_metadata["source"] = model_source
     model_metadata["scale"] = 1.0
@@ -192,8 +192,8 @@ def _update_index(model_name, model_metadata, model_source, index):
     return response
 
 
-def _add_blenderkit_model_metadata(folder_name, asset_base_id, index):
-    tags, categories, description = _get_blenderkit_metadata(folder_name)
+def add_blenderkit_model_metadata(folder_name, asset_base_id, index):
+    tags, categories, description = get_blenderkit_metadata(folder_name)
     metadata = {
         "tags": tags,
         "categories": categories,
@@ -201,5 +201,5 @@ def _add_blenderkit_model_metadata(folder_name, asset_base_id, index):
         "assetBaseId": asset_base_id,
     }
     source = "Blenderkit_pro" if len(BLENDERKIT_PRO_API_KEY) > 0 else "Blenderkit"
-    response = _update_index(folder_name, metadata, source, index)
+    response = update_index(folder_name, metadata, source, index)
     return response

--- a/roboprop_client/utils.py
+++ b/roboprop_client/utils.py
@@ -182,7 +182,7 @@ def _get_blenderkit_metadata(folder_name):
     return tags, categories, description
 
 
-def _update_index(request, model_name, model_metadata, model_source, index):
+def _update_index(model_name, model_metadata, model_source, index):
     url_safe_name = urllib.parse.quote(model_name)
     model_metadata["source"] = model_source
     model_metadata["scale"] = 1.0
@@ -192,7 +192,7 @@ def _update_index(request, model_name, model_metadata, model_source, index):
     return response
 
 
-def _add_blenderkit_model_metadata(request, folder_name, asset_base_id, index):
+def _add_blenderkit_model_metadata(folder_name, asset_base_id, index):
     tags, categories, description = _get_blenderkit_metadata(folder_name)
     metadata = {
         "tags": tags,
@@ -201,5 +201,5 @@ def _add_blenderkit_model_metadata(request, folder_name, asset_base_id, index):
         "assetBaseId": asset_base_id,
     }
     source = "Blenderkit_pro" if len(BLENDERKIT_PRO_API_KEY) > 0 else "Blenderkit"
-    response = _update_index(request, folder_name, metadata, source, index)
+    response = _update_index(folder_name, metadata, source, index)
     return response

--- a/roboprop_client/utils.py
+++ b/roboprop_client/utils.py
@@ -2,6 +2,9 @@ import requests
 import os
 import shutil
 import zipfile
+import urllib.parse
+import json
+from roboprop_client.load_blenderkit import load_blenderkit_model
 
 FILESERVER_API_KEY = "X-DreamFactory-API-Key"
 FILESERVER_API_KEY_VALUE = os.getenv("FILESERVER_API_KEY", "")
@@ -132,3 +135,71 @@ def delete_folders(folders):
     for folder in folders:
         if os.path.exists(folder):
             shutil.rmtree(folder)
+
+
+def _add_blenderkit_thumbnail(thumbnail, folder_name):
+    thumbnail_response = requests.get(thumbnail)
+    os.makedirs(os.path.join("models", folder_name, "thumbnails"), exist_ok=True)
+    thumbnail_filename = os.path.basename(thumbnail)
+    thumbnail_extension = os.path.splitext(thumbnail_filename)[1]
+    new_thumbnail_filename = "01" + thumbnail_extension
+    thumbnail_path = os.path.join(
+        "models", folder_name, "thumbnails", new_thumbnail_filename
+    )
+    with open(thumbnail_path, "wb") as thumbnail_file:
+        thumbnail_file.write(thumbnail_response.content)
+
+
+def _add_blenderkit_model_to_my_models(folder_name, asset_base_id, thumbnail):
+    load_blenderkit_model(asset_base_id, "models", folder_name)
+
+    _add_blenderkit_thumbnail(thumbnail, folder_name)
+    zip_filename, zip_path = create_zip_file(folder_name)
+    # Upload the ZIP file in a POST request
+    with open(zip_path, "rb") as zip_file:
+        files = {"files": (zip_filename, zip_file)}
+        asset_name = os.path.splitext(zip_filename)[0]
+        url = f"files/models/{asset_name}/"
+        response = make_post_request(url, files=files)
+
+    delete_folders(["models", "textures"])
+    return response
+
+
+def _get_blenderkit_metadata(folder_name):
+    tags = []
+    categories = []
+    description = []
+    url = f"files/models/{folder_name}/blenderkit_meta.json"
+    response = make_get_request(url)
+    if response.status_code == 200:
+        metadata = response.json()
+        tags = metadata.get("tags", [])
+        # Blenderkit has only one category per model, but this
+        # is a list for consistency
+        categories = [metadata.get("category", "").strip()]
+        description = metadata.get("description", "")
+    return tags, categories, description
+
+
+def _update_index(request, model_name, model_metadata, model_source, index):
+    url_safe_name = urllib.parse.quote(model_name)
+    model_metadata["source"] = model_source
+    model_metadata["scale"] = 1.0
+    model_metadata["url"] = FILESERVER_URL + f"files/models/{url_safe_name}/?zip=true"
+    index[model_name] = model_metadata
+    response = make_put_request("files/index.json", data=json.dumps(index))
+    return response
+
+
+def _add_blenderkit_model_metadata(request, folder_name, asset_base_id, index):
+    tags, categories, description = _get_blenderkit_metadata(folder_name)
+    metadata = {
+        "tags": tags,
+        "categories": categories,
+        "description": description,
+        "assetBaseId": asset_base_id,
+    }
+    source = "Blenderkit_pro" if len(BLENDERKIT_PRO_API_KEY) > 0 else "Blenderkit"
+    response = _update_index(request, folder_name, metadata, source, index)
+    return response

--- a/roboprop_client/views.py
+++ b/roboprop_client/views.py
@@ -421,7 +421,7 @@ def add_to_my_models(request):
             folder_name = utils.capitalize_and_remove_spaces(name)
             try:
                 task = add_blenderkit_model_to_my_models_task.delay(
-                    request, folder_name, asset_base_id, thumbnail, index
+                    folder_name, asset_base_id, thumbnail, index
                 )
                 response_data = {
                     "task_id": task.id,
@@ -535,7 +535,7 @@ def update_models_from_blenderkit(request):
                 thumbnail = data["thumbnailMiddleUrl"]
                 try:
                     task = add_blenderkit_model_to_my_models_task.delay(
-                        folder_name, asset_base_id, thumbnail
+                        folder_name, asset_base_id, thumbnail, index
                     )
                     response = JsonResponse({"task_id": task.id}, status=202)
                 except ValueError as e:

--- a/roboprop_client/views.py
+++ b/roboprop_client/views.py
@@ -4,18 +4,12 @@ import base64
 import xmltodict
 import json
 import os
-import urllib.parse
-import subprocess
-import zipfile
-import shutil
 import math
 from django.shortcuts import render, redirect
 from django.http import HttpResponse, JsonResponse
 from django.core.cache import cache
-from django.contrib import auth
 from django.contrib import messages
-from django.contrib.auth import update_session_auth_hash
-from roboprop_client.load_blenderkit import load_blenderkit_model
+from roboprop_client.tasks import add_blenderkit_model_to_my_models_task
 import roboprop_client.utils as utils
 
 
@@ -184,22 +178,6 @@ def _get_suggested_tags(thumbnails):
     return tags, categories, colors
 
 
-def _get_blenderkit_metadata(folder_name):
-    tags = []
-    categories = []
-    description = []
-    url = f"files/models/{folder_name}/blenderkit_meta.json"
-    response = utils.make_get_request(url)
-    if response.status_code == 200:
-        metadata = response.json()
-        tags = metadata.get("tags", [])
-        # Blenderkit has only one category per model, but this
-        # is a list for consistency
-        categories = [metadata.get("category", "").strip()]
-        description = metadata.get("description", "")
-    return tags, categories, description
-
-
 def _get_blenderkit_model_details(result):
     return {
         "name": result["name"],
@@ -227,35 +205,6 @@ def _add_fuel_model_to_my_models(name, owner):
     return response
 
 
-def _add_blenderkit_thumbnail(thumbnail, folder_name):
-    thumbnail_response = requests.get(thumbnail)
-    os.makedirs(os.path.join("models", folder_name, "thumbnails"), exist_ok=True)
-    thumbnail_filename = os.path.basename(thumbnail)
-    thumbnail_extension = os.path.splitext(thumbnail_filename)[1]
-    new_thumbnail_filename = "01" + thumbnail_extension
-    thumbnail_path = os.path.join(
-        "models", folder_name, "thumbnails", new_thumbnail_filename
-    )
-    with open(thumbnail_path, "wb") as thumbnail_file:
-        thumbnail_file.write(thumbnail_response.content)
-
-
-def _add_blenderkit_model_to_my_models(folder_name, asset_base_id, thumbnail):
-    load_blenderkit_model(asset_base_id, "models", folder_name)
-
-    _add_blenderkit_thumbnail(thumbnail, folder_name)
-    zip_filename, zip_path = utils.create_zip_file(folder_name)
-    # Upload the ZIP file in a POST request
-    with open(zip_path, "rb") as zip_file:
-        files = {"files": (zip_filename, zip_file)}
-        asset_name = os.path.splitext(zip_filename)[0]
-        url = f"files/models/{asset_name}/"
-        response = utils.make_post_request(url, files=files)
-
-    utils.delete_folders(["models", "textures"])
-    return response
-
-
 def _create_metadata_from_rekognition(name):
     thumbnails = _get_thumbnails([name], "models", page=1, page_size=1, gallery=False)
     tags, categories, colors = [], [], []
@@ -278,32 +227,6 @@ def _check_and_get_index(request):
     return index
 
 
-def _update_index(request, model_name, model_metadata, model_source):
-    index = _check_and_get_index(request)
-    url_safe_name = urllib.parse.quote(model_name)
-    model_metadata["source"] = model_source
-    model_metadata["scale"] = 1.0
-    model_metadata["url"] = (
-        utils.FILESERVER_URL + f"files/models/{url_safe_name}/?zip=true"
-    )
-    index[model_name] = model_metadata
-    response = utils.make_put_request("files/index.json", data=json.dumps(index))
-    return response
-
-
-def _add_blenderkit_model_metadata(request, folder_name, asset_base_id):
-    tags, categories, description = _get_blenderkit_metadata(folder_name)
-    metadata = {
-        "tags": tags,
-        "categories": categories,
-        "description": description,
-        "assetBaseId": asset_base_id,
-    }
-    source = "Blenderkit_pro" if len(utils.BLENDERKIT_PRO_API_KEY) > 0 else "Blenderkit"
-    response = _update_index(request, folder_name, metadata, source)
-    return response
-
-
 def _add_fuel_model_metadata(request, name, description):
     tags, categories, colors = _create_metadata_from_rekognition(name)
     metadata = {
@@ -312,8 +235,8 @@ def _add_fuel_model_metadata(request, name, description):
         "colors": colors,
         "description": description,
     }
-
-    response = _update_index(request, name, metadata, "Fuel")
+    index = _check_and_get_index(request)
+    response = utils._update_index(request, name, metadata, "Fuel", index)
     return response
 
 
@@ -476,39 +399,39 @@ def add_to_my_models(request):
     if request.method == "POST":
         name = request.POST.get("name")
         library = request.POST.get("library")
+        index = _check_and_get_index(request)
         if library == "fuel":
             owner = request.POST.get("owner")
             description = request.POST.get("description")
             response = _add_fuel_model_to_my_models(name, owner)
+            if response.status_code == 201:
+                metadata_response = _add_fuel_model_metadata(request, name, description)
+                if metadata_response.status_code == 201:
+                    response_data = {
+                        "message": f"Success: Model: {name} added to My Models, and successfully tagged"
+                    }
+                else:
+                    response_data = {
+                        "error": f"Model: {name} uploaded, but failed to tag"
+                    }
+                return JsonResponse(response_data, status=metadata_response.status_code)
         elif library == "blenderkit":
             thumbnail = request.POST.get("thumbnail")
             asset_base_id = request.POST.get("assetBaseId")
             folder_name = utils.capitalize_and_remove_spaces(name)
             try:
-                response = _add_blenderkit_model_to_my_models(
-                    folder_name, asset_base_id, thumbnail
+                task = add_blenderkit_model_to_my_models_task.delay(
+                    request, folder_name, asset_base_id, thumbnail, index
                 )
+                response_data = {
+                    "task_id": task.id,
+                    "message": "Blender to sdf conversion in progress...",
+                }
+                return JsonResponse(response_data, status=202)
             except ValueError as e:
                 return JsonResponse({"error": str(e)}, status=500)
-        metadata_response = None
-        # If model upload succeeds, add metadata
-        if response.status_code == 201 and library == "blenderkit":
-            metadata_response = _add_blenderkit_model_metadata(
-                request, folder_name, asset_base_id
-            )
-        elif response.status_code == 201 and library == "fuel":
-            metadata_response = _add_fuel_model_metadata(request, name, description)
         else:
             response_data = {"error": f"Failed to add model: {name} to My Models"}
-        # If both the model and metadata are successfully uploaded
-        if metadata_response is not None:
-            if metadata_response.status_code == 201:
-                response_data = {
-                    "message": f"Success: Model: {name} added to My Models, and successfully tagged"
-                }
-            else:
-                response_data = {"error": f"Model: {name} uploaded, but failed to tag"}
-        return JsonResponse(response_data, status=response.status_code)
     else:
         return JsonResponse({"error": "Invalid request method"}, status=405)
 
@@ -567,8 +490,8 @@ def add_metadata(request, name):
             "categories": categories,
             "colors": colors,
         }
-
-        response = _update_index(request, name, metadata, "Upload")
+        index = _check_and_get_index(request)
+        response = utils._update_index(request, name, metadata, "Upload", index)
         if response.status_code == 201:
             messages.success(request, "Model tagged successfully")
         else:
@@ -610,9 +533,13 @@ def update_models_from_blenderkit(request):
                 )
                 data = result.json()["results"][0]
                 thumbnail = data["thumbnailMiddleUrl"]
-                response = _add_blenderkit_model_to_my_models(
-                    folder_name, asset_base_id, thumbnail
-                )
+                try:
+                    task = add_blenderkit_model_to_my_models_task.delay(
+                        folder_name, asset_base_id, thumbnail
+                    )
+                    response = JsonResponse({"task_id": task.id}, status=202)
+                except ValueError as e:
+                    return JsonResponse({"error": str(e)}, status=500)
                 if response.status_code != 201:
                     return JsonResponse(
                         {"error": f"Update Failed"}, status=response.status_code

--- a/roboprop_client/views.py
+++ b/roboprop_client/views.py
@@ -236,7 +236,7 @@ def _add_fuel_model_metadata(request, name, description):
         "description": description,
     }
     index = _check_and_get_index(request)
-    response = utils._update_index(name, metadata, "Fuel", index)
+    response = utils.update_index(name, metadata, "Fuel", index)
     return response
 
 
@@ -512,7 +512,7 @@ def add_metadata(request, name):
             "colors": colors,
         }
         index = _check_and_get_index(request)
-        response = utils._update_index(name, metadata, "Upload", index)
+        response = utils.update_index(name, metadata, "Upload", index)
         if response.status_code == 201:
             messages.success(request, "Model tagged successfully")
         else:


### PR DESCRIPTION
This PR moves the blenderkit to sdf conversion process to a background worker (Through Celery) allowing the server to (most importantly) not crash, but is also non blocking leaving the user to do other things while its is running. 

The PR is a bit weighty (my apologies), much of it is moving functions around to prevent circular call errors. And it should be useful in future for other long running tasks we may want to introduce.

The tests also went through a rewrite with the new serverside login requirement blocking view tests. 