### PR TITLE
Blender conversion polling

### DIFF
--- a/roboprop/settings.py
+++ b/roboprop/settings.py
@@ -162,6 +162,8 @@ SESSION_ENGINE = "django.contrib.sessions.backends.signed_cookies"
 DATA_UPLOAD_MAX_MEMORY_SIZE = 104857600  # 100MB
 FILE_UPLOAD_MAX_MEMORY_SIZE = 104857600  # 100MB
 
-CELERY_RESULT_BACKEND = os.environ.get("CELERY_BROKER_REDIS_URL", "redis://localhost:6379")
+CELERY_RESULT_BACKEND = os.environ.get(
+    "CELERY_BROKER_REDIS_URL", "redis://localhost:6379"
+)
 CELERY_BROKER_URL = os.environ.get("CELERY_BROKER_REDIS_URL", "redis://localhost:6379")
 CELERY_BEAT_SCHEDULER = "django_celery_beat.schedulers.DatabaseScheduler"

--- a/roboprop_client/urls.py
+++ b/roboprop_client/urls.py
@@ -18,5 +18,5 @@ urlpatterns = [
         views.update_models_from_blenderkit,
         name="update_models_from_blenderkit",
     ),
-    path("task-status/<str:task_id>/", views.task_status, name="task_status")
+    path("task-status/<str:task_id>/", views.task_status, name="task_status"),
 ]

--- a/roboprop_client/urls.py
+++ b/roboprop_client/urls.py
@@ -18,4 +18,5 @@ urlpatterns = [
         views.update_models_from_blenderkit,
         name="update_models_from_blenderkit",
     ),
+    path("task-status/<str:task_id>/", views.task_status, name="task_status")
 ]

--- a/roboprop_client/views.py
+++ b/roboprop_client/views.py
@@ -25,8 +25,10 @@ def login_required(view_func):
             if response.status_code == 200:
                 return view_func(request, *args, **kwargs)
         # Check if ajax request
-        if request.headers.get('x-requested-with') == 'XMLHttpRequest':
-            return JsonResponse({"error": "You need to be logged in to access this page."}, status=401)
+        if request.headers.get("x-requested-with") == "XMLHttpRequest":
+            return JsonResponse(
+                {"error": "You need to be logged in to access this page."}, status=401
+            )
         else:
             messages.error(request, "You need to be logged in to access this page.")
             return redirect("login")
@@ -582,12 +584,10 @@ def update_models_from_blenderkit(request):
             )
     else:
         return JsonResponse({"error": "Invalid request method"}, status=405)
-    
+
 
 @login_required
 def task_status(request, task_id):
     task = AsyncResult(task_id)
-    response_data = {
-        "status": task.status
-    }
+    response_data = {"status": task.status}
     return JsonResponse(response_data)

--- a/roboprop_client/views.py
+++ b/roboprop_client/views.py
@@ -10,6 +10,7 @@ from django.http import HttpResponse, JsonResponse
 from django.core.cache import cache
 from django.contrib import messages
 from roboprop_client.tasks import add_blenderkit_model_to_my_models_task
+from celery.result import AsyncResult
 import roboprop_client.utils as utils
 
 
@@ -23,9 +24,12 @@ def login_required(view_func):
             )
             if response.status_code == 200:
                 return view_func(request, *args, **kwargs)
-
-        messages.error(request, "You need to be logged in to access this page.")
-        return redirect("login")
+        # Check if ajax request
+        if request.headers.get('x-requested-with') == 'XMLHttpRequest':
+            return JsonResponse({"error": "You need to be logged in to access this page."}, status=401)
+        else:
+            messages.error(request, "You need to be logged in to access this page.")
+            return redirect("login")
 
     return _wrapped_view_func
 
@@ -578,3 +582,12 @@ def update_models_from_blenderkit(request):
             )
     else:
         return JsonResponse({"error": "Invalid request method"}, status=405)
+    
+
+@login_required
+def task_status(request, task_id):
+    task = AsyncResult(task_id)
+    response_data = {
+        "status": task.status
+    }
+    return JsonResponse(response_data)

--- a/templates/find-models.html
+++ b/templates/find-models.html
@@ -67,6 +67,29 @@
         <p class="m-3">No models found for search term: {{ search }} </p>
     {% endif %}
     <script>
+        function pollTaskStatus(taskId) {
+            const notification = document.querySelector('#notification');
+            $.ajax({
+                url: "/task-status/" + taskId + "/",
+                type: 'GET',
+                success: function(response) {
+                    if (response.status === "SUCCESS") {
+                        notification.innerHTML = "Model added successfully";
+                        notification.classList.remove("bg-red-500/80");
+                        notification.classList.add("bg-green-500/80");
+                    } else if (response.status === "FAILURE") {
+                        notification.innerHTML = "Failed to add model";
+                        notification.classList.remove("bg-green-500/80");
+                        notification.classList.add("bg-red-500/80");
+                    } else {
+                        setTimeout(function() {
+                            pollTaskStatus(taskId);
+                        }, 1000);
+                    }
+                }
+            });
+        }
+
         function addModel(data) {
             const notification = document.querySelector('#notification');
             notification.innerHTML = '';
@@ -82,6 +105,7 @@
                     notification.classList.remove('hidden');
                     notification.classList.remove('bg-red-500/80');
                     notification.classList.add('bg-green-500/80');
+                    pollTaskStatus(response.task_id)
                 },
                 error: function(error) {
                     notification.innerHTML = error.responseJSON.error;


### PR DESCRIPTION
Adds Polling to roboprop allowing for long running processes (in this case blender conversions) to get status feedback updates from the UI via ajax. 

This is simple at the moment (just success / fail messages) and completes the current round of background task implementations.

Improved UI (whether it be popups, notifications, different messages for different states etc.) has been added as a general issues to #94 

This PR closes #88 