### PR TITLE
Invert Yaw, change to fbx

### DIFF
--- a/roboprop_client/export_model.py
+++ b/roboprop_client/export_model.py
@@ -8,7 +8,7 @@ from roboprop_client.blender_scripts.export_obj import export_obj
 
 EXPORT_CONFIGS = [
     {
-        "visual": "assets/visual.obj",
+        "visual": "assets/visual.fbx",
         "sdf": "model.sdf",
         "config": "model.config",
     },
@@ -72,7 +72,7 @@ def export_sdf(out_dir: Path, model_name: str, blend_file_path: Path):
         )
         pose = ElementTree.SubElement(link, "pose")
         pose.set("degrees", "1")
-        pose.text = "0 0 0 90 0 -90"
+        pose.text = "0 0 0 90 0 90"
 
         visual = ElementTree.SubElement(
             link, "visual", attrib={"name": f"{model_name}_visual"}

--- a/roboprop_client/export_model.py
+++ b/roboprop_client/export_model.py
@@ -72,7 +72,7 @@ def export_sdf(out_dir: Path, model_name: str, blend_file_path: Path):
         )
         pose = ElementTree.SubElement(link, "pose")
         pose.set("degrees", "1")
-        pose.text = "0 0 0 90 0 90"
+        pose.text = "0 0 0 90 0 -90"
 
         visual = ElementTree.SubElement(
             link, "visual", attrib={"name": f"{model_name}_visual"}


### PR DESCRIPTION
So by changing to FBX the textures appear nicely in Gazebo. As can be seen in the below two screenshots (before / after)

![image](https://github.com/art-e-fact/RoboProp/assets/68368403/13a97ebd-6a37-46ad-911d-f413152d40f0)
![image (1)](https://github.com/art-e-fact/RoboProp/assets/68368403/b7ece394-831d-4fb1-a30a-08e98330bdbf)

However, as you can see, the models are rotated incorrectly (on yaw). I've resolved this by inverting the pose in the sdf file, but not 100% if thats the right place (further comment on the line changed). It does work as you can see here:

![image (2)](https://github.com/art-e-fact/RoboProp/assets/68368403/cdf3bc96-ddc7-479f-bea8-015a88314039)

Closes #102 