### PR TITLE
Simple collision meshes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,3 +95,5 @@ static/src/output.css
 models/
 textures/
 staticfiles/
+
+.DS_Store

--- a/roboprop_client/blender_scripts/export_fbx.py
+++ b/roboprop_client/blender_scripts/export_fbx.py
@@ -27,7 +27,6 @@ def export_fbx(blend_file: Path, output: Path, collision_output: Path):
             decimate_modifier = obj.modifiers.new('DecimateMod', 'DECIMATE')
             decimate_modifier.ratio = 0.1  # Adjust this value to get the desired level of simplification
 
-            # Set the object as the active object
             bpy.context.view_layer.objects.active = obj
             obj.select_set(True)
 

--- a/roboprop_client/blender_scripts/export_fbx.py
+++ b/roboprop_client/blender_scripts/export_fbx.py
@@ -2,7 +2,7 @@ import bpy
 from pathlib import Path
 
 
-def export_fbx(blend_file: Path, output: Path):
+def export_fbx(blend_file: Path, output: Path, collision_output: Path):
     # Reset the state of Blender
     bpy.ops.wm.read_factory_settings(use_empty=True)
     # Load the blend file
@@ -18,4 +18,46 @@ def export_fbx(blend_file: Path, output: Path):
         path_mode="COPY",
         embed_textures=False,  # Gazebo can't handle embedded textures
         apply_scale_options="FBX_SCALE_ALL",
+    )
+
+       # Create a simplified collision model
+    for obj in bpy.context.scene.objects:
+        if obj.type == 'MESH':
+            # Add a Decimate modifier to reduce the number of polygons
+            decimate_modifier = obj.modifiers.new('DecimateMod', 'DECIMATE')
+            decimate_modifier.ratio = 0.1  # Adjust this value to get the desired level of simplification
+
+            # Set the object as the active object
+            bpy.context.view_layer.objects.active = obj
+            obj.select_set(True)
+
+            # Apply the Decimate modifier
+            bpy.ops.object.modifier_apply(modifier=decimate_modifier.name)
+
+            # Create a Convex Hull from the object
+            bpy.ops.object.mode_set(mode='EDIT')  # Enter edit mode
+            bpy.ops.mesh.select_all(action='SELECT')  # Select all vertices
+            bpy.ops.mesh.convex_hull()  # Create the convex hull
+            bpy.ops.object.mode_set(mode='OBJECT')  # Return to object mode
+
+    # Export the collision model
+    bpy.ops.export_scene.fbx(
+        filepath=str(collision_output),
+        check_existing=False,
+        object_types={"MESH"},
+        path_mode="COPY",
+        embed_textures=False,
+        use_mesh_modifiers=True,
+        mesh_smooth_type='FACE',
+        use_mesh_edges=False,
+        use_tspace=False,
+        use_custom_props=False,
+        add_leaf_bones=False,
+        primary_bone_axis='Y',
+        secondary_bone_axis='X',
+        use_armature_deform_only=True,
+        bake_anim=False,
+        use_metadata=False,
+        apply_scale_options="FBX_SCALE_ALL",
+        use_triangles=True,  # Convert all geometry to triangles
     )

--- a/roboprop_client/blender_scripts/export_fbx.py
+++ b/roboprop_client/blender_scripts/export_fbx.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 
 def export_fbx(blend_file: Path, output: Path, collision_output: Path):
+    # Visual model
     # Reset the state of Blender
     bpy.ops.wm.read_factory_settings(use_empty=True)
     # Load the blend file
@@ -20,24 +21,21 @@ def export_fbx(blend_file: Path, output: Path, collision_output: Path):
         apply_scale_options="FBX_SCALE_ALL",
     )
 
-       # Create a simplified collision model
+    # Collision model
     for obj in bpy.context.scene.objects:
-        if obj.type == 'MESH':
-            # Add a Decimate modifier to reduce the number of polygons
-            decimate_modifier = obj.modifiers.new('DecimateMod', 'DECIMATE')
-            decimate_modifier.ratio = 0.1  # Adjust this value to get the desired level of simplification
-
+        if obj.type == "MESH":
+            # Decimate modifier
+            decimate_modifier = obj.modifiers.new("DecimateMod", "DECIMATE")
+            decimate_modifier.ratio = 0.5  # Lower is simpler
             bpy.context.view_layer.objects.active = obj
             obj.select_set(True)
-
-            # Apply the Decimate modifier
             bpy.ops.object.modifier_apply(modifier=decimate_modifier.name)
 
-            # Create a Convex Hull from the object
-            bpy.ops.object.mode_set(mode='EDIT')  # Enter edit mode
-            bpy.ops.mesh.select_all(action='SELECT')  # Select all vertices
-            bpy.ops.mesh.convex_hull()  # Create the convex hull
-            bpy.ops.object.mode_set(mode='OBJECT')  # Return to object mode
+            # Remesh modifier
+            remesh_modifier = obj.modifiers.new("RemeshMod", "REMESH")
+            remesh_modifier.mode = "SMOOTH"  # BLOCKS, SMOOTH, or SHARP
+            remesh_modifier.octree_depth = 6  # Lower is simpler
+            bpy.ops.object.modifier_apply(modifier=remesh_modifier.name)
 
     # Export the collision model
     bpy.ops.export_scene.fbx(
@@ -47,13 +45,13 @@ def export_fbx(blend_file: Path, output: Path, collision_output: Path):
         path_mode="COPY",
         embed_textures=False,
         use_mesh_modifiers=True,
-        mesh_smooth_type='FACE',
+        mesh_smooth_type="FACE",
         use_mesh_edges=False,
         use_tspace=False,
         use_custom_props=False,
         add_leaf_bones=False,
-        primary_bone_axis='Y',
-        secondary_bone_axis='X',
+        primary_bone_axis="Y",
+        secondary_bone_axis="X",
         use_armature_deform_only=True,
         bake_anim=False,
         use_metadata=False,

--- a/roboprop_client/export_model.py
+++ b/roboprop_client/export_model.py
@@ -75,7 +75,7 @@ def export_sdf(out_dir: Path, model_name: str, blend_file_path: Path):
         )
         pose = ElementTree.SubElement(link, "pose")
         pose.set("degrees", "1")
-        pose.text = "0 0 0 90 0 90"
+        pose.text = "0 0 0 90 0 -90"
 
         visual = ElementTree.SubElement(
             link, "visual", attrib={"name": f"{model_name}_visual"}

--- a/roboprop_client/export_model.py
+++ b/roboprop_client/export_model.py
@@ -8,12 +8,14 @@ from roboprop_client.blender_scripts.export_obj import export_obj
 
 EXPORT_CONFIGS = [
     {
-        "visual": "assets/visual.obj",
+        "visual": "assets/visual.fbx",
+        "collision": "assets/collision.fbx",
         "sdf": "model.sdf",
         "config": "model.config",
     },
     {
         "visual": "assets/visual.glb",
+        "collision": "assets/visual.glb",
         "sdf": "glft-model.sdf",
         "config": "glft-model.config",
     },
@@ -36,13 +38,14 @@ def export_sdf(out_dir: Path, model_name: str, blend_file_path: Path):
 
     for export_config in EXPORT_CONFIGS:
         visual_path = out_dir / export_config["visual"]
+        collision_path = out_dir / export_config["collision"]
         sdf_path = out_dir / export_config["sdf"]
         config_path = out_dir / export_config["config"]
 
         # Export visual model
         os.makedirs(name=os.path.dirname(visual_path), exist_ok=True)
         if Path(visual_path).suffix == ".fbx":
-            export_fbx(blend_file_path, visual_path)
+            export_fbx(blend_file_path, visual_path, collision_path)
         elif Path(visual_path).suffix == ".glb":
             export_glb(blend_file_path, visual_path)
         elif Path(visual_path).suffix == ".gltf":
@@ -72,7 +75,7 @@ def export_sdf(out_dir: Path, model_name: str, blend_file_path: Path):
         )
         pose = ElementTree.SubElement(link, "pose")
         pose.set("degrees", "1")
-        pose.text = "0 0 0 90 0 -90"
+        pose.text = "0 0 0 90 0 90"
 
         visual = ElementTree.SubElement(
             link, "visual", attrib={"name": f"{model_name}_visual"}
@@ -88,7 +91,7 @@ def export_sdf(out_dir: Path, model_name: str, blend_file_path: Path):
         collision_mesh = ElementTree.SubElement(collision_geometry, "mesh")
         collision_mesh_uri = ElementTree.SubElement(collision_mesh, "uri")
         collision_mesh_uri.text = os.path.relpath(
-            visual_path, os.path.dirname(sdf_path)
+            collision_path, os.path.dirname(sdf_path)
         )
 
         write_xml(sdf, sdf_path)


### PR DESCRIPTION
Adds a simple(ish) collision mesh dynamically when models are converted from blender. After experimenting with decimation, convex hulls, and remeshing (as well as breaking up the model into parts, applying those factors, and putting it back together), Decimation and Remeshing seems to offer the best balance of accuracy and performance. Smooth remeshing rather than "block" seems to be better for our use case as well (we wouldnt want a sphere turning into a cube).

Thoughts more than welcome
![image (4)](https://github.com/art-e-fact/RoboProp/assets/68368403/440e9f47-55a3-4e0f-b43c-2a01f28f2004)

(the collision visual doesnt show up so well, but you can, for example, drop the cup on the chair seat without issue)