### PR TITLE
Fix batch blender updates

### DIFF
--- a/roboprop/settings.py
+++ b/roboprop/settings.py
@@ -167,3 +167,4 @@ CELERY_RESULT_BACKEND = os.environ.get(
 )
 CELERY_BROKER_URL = os.environ.get("CELERY_BROKER_REDIS_URL", "redis://localhost:6379")
 CELERY_BEAT_SCHEDULER = "django_celery_beat.schedulers.DatabaseScheduler"
+CELERY_TASK_TIME_LIMIT = 10 * 60  # 10 minutes

--- a/roboprop_client/blender_scripts/export_fbx.py
+++ b/roboprop_client/blender_scripts/export_fbx.py
@@ -24,6 +24,7 @@ def export_fbx(blend_file: Path, output: Path, collision_output: Path):
     # Collision model
     for obj in bpy.context.scene.objects:
         if obj.type == "MESH":
+            obj.data = obj.data.copy() # Make the mesh single user
             # Decimate modifier
             decimate_modifier = obj.modifiers.new("DecimateMod", "DECIMATE")
             decimate_modifier.ratio = 0.5  # Lower is simpler

--- a/roboprop_client/utils.py
+++ b/roboprop_client/utils.py
@@ -47,7 +47,7 @@ def make_post_request(
             url,
             files=files,
             headers={FILESERVER_API_KEY: FILESERVER_API_KEY_VALUE},
-            timeout=60,
+            timeout=540,
         )
     elif json:
         response = requests.post(


### PR DESCRIPTION
This PR does two things:

1. Fixes the update logic for the blender batch updates when reconverting
2. Adds further compatibility to blender models (e.g blenderkit) when auto-creating collision meshes by making sure everything is single user.

Need to reimplmenet the "reupload previous index.json" after a batch update (this is incase the user has manually updated index.json for better curation of metadata). Currently commented out